### PR TITLE
[MRG] Add sprint report file and sprint video demonstration guidelines

### DIFF
--- a/SPRINTREPORT.md
+++ b/SPRINTREPORT.md
@@ -60,11 +60,11 @@ These tasks were opened during the sprint but no work was done to address them.
 
 ### Challenges
 
-The team met the following challenges during this sprint.
+The team met the following challenges or blockers during this sprint.
 
 *Please include and link to the accompanying issue or pull request for each challenge point.*
 
-* `challenge description`
+* `challenge/blocker description`
   * Related to issues: [`#o`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`o`), [`#p`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`p`)
   * *Additional notes if necessary.*
 *

--- a/SPRINTREPORT.md
+++ b/SPRINTREPORT.md
@@ -1,0 +1,85 @@
+# Fujitsu sprint report
+
+This file contains reports of work completed during Fujitsu team sprints.
+
+More details about this process can be found in the [agile-opensource-workflow.md](project-management/agile-opensource-workflow.md) and [sprint-demo-requirements.md](project-management/sprint-demo-requirements.md) files in the [project-management](project-management) directory.
+
+Sprints are added in reverse order, and a template is available at the end of this file: [Sprint `N`](#sprint-n).
+
+---
+
+*The example below is a template format for each sprint report.*
+*Text in italics is intended as a guide and should be removed from the updates as they are completed.*
+*Text in `code format` should be replaced with the specific information for that sprint.*
+
+## Sprint `N`
+
+**Dates: `START` to `END`**
+
+*Please make sure dates are in ISO standard format: `YYYY-MM-DD`.*
+
+### Issues closed
+
+These tasks were closed during the sprint.
+
+*Please include and link to the accompanying pull request for each issue if applicable.*
+
+* [`#i`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`i`): `issue title`
+  * Assocated pull requests: [`#a`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`a`), [`#b`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`b`)
+  * *Additional notes if necessary.*
+* [`#j`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`j`): `issue title`
+  * Assocated pull requests: [`#c`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`c`), [`#d`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`d`)
+  * *Additional notes if necessary.*
+*
+
+### Issues progressed
+
+Progress was made on these tasks but they were not closed during the sprint.
+
+*Please include and link to the accompanying pull request for each issue if applicable.*
+
+* [`#k`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`k`): `issue title`
+  * Assocated pull requests: [`#e`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`e`), [`#f`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`f`)
+  * *Additional notes if necessary.*
+* [`#l`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`l`): `issue title`
+  * Assocated pull requests: [`#g`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`g`), [`#h`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`h`)
+  * *Additional notes if necessary.*
+*
+
+### Issues opened
+
+These tasks were opened during the sprint but no work was done to address them.
+
+*Please include and link to the accompanying pull request for each issue if applicable.*
+
+* [`#m`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`m`): `issue title`
+  * *Additional notes if necessary.*
+* [`#n`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`n`): `issue title`
+  * *Additional notes if necessary.*
+*
+
+### Challenges
+
+The team met the following challenges during this sprint.
+
+*Please include and link to the accompanying issue or pull request for each challenge point.*
+
+* `challenge description`
+  * Related to issues: [`#o`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`o`), [`#p`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`p`)
+  * *Additional notes if necessary.*
+*
+*
+
+### Request for community feedback
+
+Feedback is requested from the community on the following tasks.
+
+*Please include and link to the accompanying issue or pull request for each request for feedback point.*
+*This section should always include an issue to collect feedback on this sprint demo release.*
+
+* [`#M`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`M`): issue to collect feedback on sprint `N`
+  * Link to video: [`link-to-youtube`](`link-to-youtube`)
+  * Link to sprint report: [SPRINTREPORT.md#`N`](SPRINTREPORT.md#sprint-`N`)
+*
+*
+

--- a/project-management/sprint-demo-requirements.md
+++ b/project-management/sprint-demo-requirements.md
@@ -1,0 +1,100 @@
+# Public demonstration of sprint progress
+
+This document describes the video and updates to the sprint report text file that are shared at the end of each Agile sprint by the Fujitsu team.
+
+ ## Background, problem statement, proposed solution
+
+Described in more detail in [agile-opensource-workflow.md](agile-opensource-workflow.md), there is a tension between *continual* and *continuous* project development.
+
+Specifically, defining work at the beginning of a (usually 2 week) sprint makes it difficult for members of the autistic community to share their feedback with the Fujitsu project team.
+A traditional Agile workflow would require them to be present for the end of sprint demonstration.
+People who are not paid to be part of the project will struggle to be available at those specific times.
+By only presenting to a small group of community members we will not deliver on our values of a [*participatory*](project-values.md#participatory-science) and [*inclusive*](project-values.md#diversity-and-inclusion) development project.
+
+Our proposed solution is to publicly release a video visually presenting the work that has been done during the sprint and a text sprint report file detailing the issues and pull requests that were addressed during the sprint.
+
+Members of the project community include autistic people, their families, members of the Open Humans community, autism researchers, Turing Institute researchers and open source contributors more broadly.
+These community members can watch the video and read the sprint report at any time and share their feedback via GitHub or the "always open" Google form.
+
+## Sprint report
+
+The [sprint report text file](/SPRINTREPORT.md) is similar to a [standard changelog file](https://keepachangelog.com/en/1.0.0/).
+The goal of the sprint report is to capture project progress.
+
+It is distinct from the changelog which is only updated on a new release of the project.
+
+The sprint report should contain a list of issues that have been [closed](#closed-issues), [progressed](#progressed-issues) or [opened](#opened-issues) during the sprint.
+It should also include a bullet point list of [challenges](#challenges) that the team faced, and any issues where [community feedback](#community-feedback-requests) is particularly requested.
+
+### Closed issues
+
+This section of the sprint report contains links to issues that were closed during the sprint.
+Associated merged pull requests should also be linked (if applicable).
+
+If necessary, change the issue title to make the sprint report easier to read.
+
+Template section format:
+
+> * [`#i`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`i`): `issue title`
+>   * Assocated pull requests: [`#a`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`a`), [`#b`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`b`)
+>   * *Additional notes if necessary.*
+
+### Progressed issues
+
+This section of the sprint report contains links to issues that were addressed during the sprint but which are not yet closed.
+Associated "work in progress" (`[WIP]`) or "ready for review" (`[MRG]`) pull requests should also be linked (if applicable).
+
+If necessary, change the issue title to make the sprint report easier to read.
+
+Template section format:
+
+> * [`#k`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`k`): `issue title`
+>   * Assocated pull requests: [`#e`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`e`), [`#f`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`f`)
+>   * *Additional notes if necessary.*
+
+### Opened issues
+
+This section of the sprint report contains links to issues that were opened but not addressed during the sprint.
+
+If necessary, change the issue title to make the sprint report easier to read.
+
+Template section format:
+
+> * [`#m`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`m`): `issue title`
+>   * *Additional notes if necessary.*
+
+### Challenges
+
+This section of the sprint report captures challenges that the Fujitsu team faced during the sprint.
+The challenges should include links to the relavent issues and pull requests where applicable.
+
+> * `challenge description`
+>   * Related to issues: [`#o`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`o`), [`#p`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`p`)
+>   * *Additional notes if necessary.*
+
+### Community Feedback Requests
+
+This section of the sprint report captures issues and pull requests where community feedback is particularly requested.
+
+This section should always link to an issue asking for feedback on the sprint demo itself.
+That issue must contain a link to the video and to the appropriate section in the Fujistu [sprint report](/SPRINTREPORT.md).
+
+This section may also contain links to working prototypes of the website that community members can interact with and provide their thoughts on.
+Make sure that these links have associated issues to capture the feedback (which can be the same as the sprint report issue, or a separate one as appropriate).
+
+> * [`#M`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`M`): issue to collect feedback on sprint `N`
+>   * Link to video: [`link-to-youtube`](`link-to-youtube`)
+>   * Link to sprint report: [SPRINTREPORT.md#`N`](SPRINTREPORT.md#sprint-`N`)
+>   * Link to interactive wireframe/prototype: [`link-to-wireframe`](`link-to-wireframe`)
+
+## Video
+
+
+## Sprint timeline
+
+Sprint report and video posted on Thursday.
+
+Retrospective and Sprint Planning meeting on Monday.
+
+Fujitsu team read a chapter of Autistm book book SFW on the Friday between.
+

--- a/project-management/sprint-demo-requirements.md
+++ b/project-management/sprint-demo-requirements.md
@@ -11,10 +11,10 @@ A traditional Agile workflow would require them to be present for the end of spr
 People who are not paid to be part of the project will struggle to be available at those specific times.
 By only presenting to a small group of community members we will not deliver on our values of a [*participatory*](project-values.md#participatory-science) and [*inclusive*](project-values.md#diversity-and-inclusion) development project.
 
-Our proposed solution is to publicly release a video visually presenting the work that has been done during the sprint and a text sprint report file detailing the issues and pull requests that were addressed during the sprint.
+Our proposed solution is to publicly release a [video](#video) visually presenting the work that has been done during the sprint and a [sprint report](#sprint-report) text file detailing the issues and pull requests that were addressed during the sprint.
 
 Members of the project community include autistic people, their families, members of the Open Humans community, autism researchers, Turing Institute researchers and open source contributors more broadly.
-These community members can watch the video and read the sprint report at any time and share their feedback via GitHub or the "always open" Google form.
+These community members can watch the video and read the sprint report at any time and share their feedback via [GitHub issues](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/master/CONTRIBUTING.md#where-to-start-issues) or the ["always open" Google form](https://bit.ly/AutisticaTuringCitSciForm).
 
 ## Sprint report
 
@@ -33,7 +33,7 @@ Associated merged pull requests should also be linked (if applicable).
 
 If necessary, change the issue title to make the sprint report easier to read.
 
-Template section format:
+#### Template section format:
 
 > * [`#i`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`i`): `issue title`
 >   * Assocated pull requests: [`#a`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`a`), [`#b`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`b`)
@@ -46,7 +46,7 @@ Associated "work in progress" (`[WIP]`) or "ready for review" (`[MRG]`) pull req
 
 If necessary, change the issue title to make the sprint report easier to read.
 
-Template section format:
+#### Template section format
 
 > * [`#k`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`k`): `issue title`
 >   * Assocated pull requests: [`#e`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`e`), [`#f`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`f`)
@@ -58,7 +58,7 @@ This section of the sprint report contains links to issues that were opened but 
 
 If necessary, change the issue title to make the sprint report easier to read.
 
-Template section format:
+#### Template section format
 
 > * [`#m`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`m`): `issue title`
 >   * *Additional notes if necessary.*
@@ -67,6 +67,8 @@ Template section format:
 
 This section of the sprint report captures challenges that the Fujitsu team faced during the sprint.
 The challenges should include links to the relavent issues and pull requests where applicable.
+
+#### Template section format
 
 > * `challenge description`
 >   * Related to issues: [`#o`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`o`), [`#p`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`p`)
@@ -82,6 +84,8 @@ That issue must contain a link to the video and to the appropriate section in th
 This section may also contain links to working prototypes of the website that community members can interact with and provide their thoughts on.
 Make sure that these links have associated issues to capture the feedback (which can be the same as the sprint report issue, or a separate one as appropriate).
 
+#### Template section format
+
 > * [`#M`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`M`): issue to collect feedback on sprint `N`
 >   * Link to video: [`link-to-youtube`](`link-to-youtube`)
 >   * Link to sprint report: [SPRINTREPORT.md#`N`](SPRINTREPORT.md#sprint-`N`)
@@ -89,12 +93,41 @@ Make sure that these links have associated issues to capture the feedback (which
 
 ## Video
 
+The video is a 3-5 minute summary of the sprint report.
+
+We recommend formatting it as screen captured presentation with spoken descriptions.
+
+The screen capture may include a powerpoint presentation of the [closed](#closed-issues), [progressed](#progressed-issues) and [opened](#opened-issues) issues, the [challenges](#challenges) that the team faced, and to highlight requests for[community feedback](#community-feedback-requests).
+Alternatively the recording could be of a navigation of changed to the GitHub repository.
+
+The video recording is particularly helpful in showing how community members can navigate interactive wireframes or prototypes.
+
+The video should be uploaded to YouTube and made publicly available.
 
 ## Sprint timeline
 
-Sprint report and video posted on Thursday.
+This documentation assumes a two week / ten working day sprint that starts on a Monday (day 1) and finishes on a Friday (day 10).
 
-Retrospective and Sprint Planning meeting on Monday.
+### Sprint report and video
 
-Fujitsu team read a chapter of Autistm book book SFW on the Friday between.
+We recommend that the sprint report and video are uploaded on day 9 (Thursday) to give members of the research team at the Alan Turing Institute time to watch the video.
+
+**It is the responsibility of the Fujitsu development team to ensure that they have internal approval to release the video publicly before the end of the sprint.**
+
+### Sprint retrospective and planning meeting
+
+The sprint retrospective discussion will take place on the first day of the next sprint (day 1, Monday).
+
+In this meeting the Fujitsu team members, researchers at the Alan Turing Institute, and representatives of the autistic community will discuss the work shared in the sprint report and accompanying video.
+
+After the retrospective, the project team will set priorities for the next sprint.
+
+### Learning and development day
+
+Day 10 (Friday) of the two week sprint is designated as a learning and development day.
+We recommend that the Fujitsu team use this day to learn more about autism and the autistic community.
+
+The Turing research team recommend that this day is spent reading and discussing [Autism: A New Introduction to Psychological Theory and Current Debate](https://smile.amazon.co.uk/Autism-Introduction-Psychological-Theory-Current/dp/1138106127) by Dr [Sue Fletcher-Watson](https://www.ed.ac.uk/profile/dr-sue-fletcher-watson) and Prof [Francesca Happé](https://www.kcl.ac.uk/people/francesca-happe).
+Each chapter is less than 20 pages long and suitable for a general audience.
+The team could read one chapter per sprint cycle and reflect together on how their work is delivering on the needs of the autistic community.
 

--- a/project-management/sprint-demo-requirements.md
+++ b/project-management/sprint-demo-requirements.md
@@ -116,7 +116,7 @@ We recommend that the sprint report and video are uploaded on day 9 (Thursday) t
 
 ### Sprint retrospective and planning meeting
 
-The sprint retrospective discussion will take place on the first day of the next sprint (day 1, Monday).
+The sprint retrospective discussion will take place on the 10th day of the sprint.
 
 In this meeting the Fujitsu team members, researchers at the Alan Turing Institute, and at least one member of the autistic community will discuss the work shared in the sprint report and accompanying video.
 

--- a/project-management/sprint-demo-requirements.md
+++ b/project-management/sprint-demo-requirements.md
@@ -1,6 +1,6 @@
 # Public demonstration of sprint progress
 
-This document describes the video and updates to the sprint report text file that are shared at the end of each Agile sprint by the Fujitsu team.
+This document describes the video and updates to the sprint report text file that are publicly shared at the end of each Agile sprint by the Fujitsu team.
 
  ## Background, problem statement, proposed solution
 
@@ -13,13 +13,13 @@ By only presenting to a small group of community members we will not deliver on 
 
 Our proposed solution is to publicly release a [video](#video) visually presenting the work that has been done during the sprint and a [sprint report](#sprint-report) text file detailing the issues and pull requests that were addressed during the sprint.
 
-Members of the project community include autistic people, their families, members of the Open Humans community, autism researchers, Turing Institute researchers and open source contributors more broadly.
-These community members can watch the video and read the sprint report at any time and share their feedback via [GitHub issues](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/master/CONTRIBUTING.md#where-to-start-issues) or the ["always open" Google form](https://bit.ly/AutisticaTuringCitSciForm).
+Members of the project community include autistic people, their families, members of the Open Humans development community, autism researchers, Turing Institute researchers and open source contributors more broadly.
+These community members can watch the video and read the sprint report at any time and share their feedback via [GitHub issues](/CONTRIBUTING.md#where-to-start-issues) or the ["always open" Google form](https://bit.ly/AutisticaTuringCitSciForm).
 
 ## Sprint report
 
 The [sprint report text file](/SPRINTREPORT.md) is similar to a [standard changelog file](https://keepachangelog.com/en/1.0.0/).
-The goal of the sprint report is to capture project progress.
+The goal of the sprint report is to communicate project progress to stakeholders including the Turing research team and community members who are not able to attend the [sprint retrospective and planning meeting](#sprint-retrospective-and-planning-meeting).
 
 It is distinct from the changelog which is only updated on a new release of the project.
 
@@ -33,7 +33,7 @@ Associated merged pull requests should also be linked (if applicable).
 
 If necessary, change the issue title to make the sprint report easier to read.
 
-#### Template section format:
+#### Template section format
 
 > * [`#i`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`i`): `issue title`
 >   * Assocated pull requests: [`#a`](https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/`a`), [`#b`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`b`)
@@ -65,16 +65,16 @@ If necessary, change the issue title to make the sprint report easier to read.
 
 ### Challenges
 
-This section of the sprint report captures challenges that the Fujitsu team faced during the sprint.
-The challenges should include links to the relavent issues and pull requests where applicable.
+This section of the sprint report captures challenges and blockers that the Fujitsu team faced during the sprint.
+The challenges should include links to the relevant issues and pull requests where applicable.
 
 #### Template section format
 
-> * `challenge description`
+> * `challenge/blocker description`
 >   * Related to issues: [`#o`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`o`), [`#p`](https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/`p`)
 >   * *Additional notes if necessary.*
 
-### Community Feedback Requests
+### Community feedback requests
 
 This section of the sprint report captures issues and pull requests where community feedback is particularly requested.
 
@@ -118,7 +118,10 @@ We recommend that the sprint report and video are uploaded on day 9 (Thursday) t
 
 The sprint retrospective discussion will take place on the first day of the next sprint (day 1, Monday).
 
-In this meeting the Fujitsu team members, researchers at the Alan Turing Institute, and representatives of the autistic community will discuss the work shared in the sprint report and accompanying video.
+In this meeting the Fujitsu team members, researchers at the Alan Turing Institute, and at least one member of the autistic community will discuss the work shared in the sprint report and accompanying video.
+
+This discussion will always include a reflection on community feedback provided on the _previous_ sprint.
+If necessary new user stories will be created and added to the backlog.
 
 After the retrospective, the project team will set priorities for the next sprint.
 


### PR DESCRIPTION
Addresses in part - but does not close - #92 

Changes in this PR:

* Guidelines for sprint report and video, including sprint timeline
* Template for sprint report file that will be updated at the end of each sprint

Reviewers should feedback on the process described in [project-management/sprint-demo-requirements.md](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/sprint-video-demo/project-management/sprint-demo-requirements.md).

👉 In particular, Fujitsu team members should discuss the timeline for the sprint video release and learning and development work on day 10, as this is likely a major change from the traditional Agile workflow.