### PR TITLE
Create focus-group-summaries-2019.md

### DIFF
--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -6,7 +6,7 @@ Based on the feedback receieved, none of the content was requested to be changed
 
 * [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
 * [24th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-24092019)
-* [04th October 2019](#date-04th-october-2019)
+* [04th October 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-04102019)
 
 ### Key
 

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -6,7 +6,7 @@ Based on the feedback receieved, none of the content was requested to be changed
 
 ## Contents
 
-* [Key]
+* [Key](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#key)
 
 * [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
 
@@ -116,8 +116,8 @@ Based on the feedback receieved, none of the content was requested to be changed
 
 ### Supporting and improving research
 
-* (••A•• g): “recently [in] one of the journals someone did a meta-analysis called ‘sensory experiences’, and it’s so prevalent it should be included in the core characteristics of autism, which it isn’t currently”
-* (••A•• d): “I’m very interested in what are the ways the data is captured – how it could be interpreted with fidelity, so we don’t lose the meaning”
+* (**A** g): “recently [in] one of the journals someone did a meta-analysis called ‘sensory experiences’, and it’s so prevalent it should be included in the core characteristics of autism, which it isn’t currently”
+* (**A** d): “I’m very interested in what are the ways the data is captured – how it could be interpreted with fidelity, so we don’t lose the meaning”
 * (R *T* d): “I’m really interested now in how we can do open and ethical and transparent research which is slightly more impactful on a shorter-term basis than neuroimaging”
 
 ### Long term benefits

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -982,3 +982,497 @@ First step (currently) is creating an Open Humans account:
 * (*F* d): Link to the Autistica conference using live streaming to promote the platform
 * (R *T* d): Wait until contribution platforms are clearer before doing a big marketing push
 
+# CITIZEN SCIENCE FOCUS GROUP 04/10/2019 
+
+## *Thematic Summary*
+
+## 1. Value of project and motivations to take part
+
+### a) General
+
+* (R *T* g): “I think there are multiple different aspects of why people are interested”
+
+### b) Helping autistic people and their families
+
+* (**P** *F* d): “I want to do whatever I can to help [my son] and everyone else with autistic spectrum condition.”
+* (**A** **P** *A* R d): “we’re not interested in autism, we’re interested in autistic people and their families, and ultimately how we can improve their lives, so this project is one of the most exciting examples of that”
+* (R *T* d): “it’s hugely motivating, because I can see the value in it to actually have a huge impact on people’s daily lives”
+* (**A** **P** d): “…make it easier for people to, I wouldn’t say function, I would say live…bring their talents out, uncover their potential”
+* (*F* d): Impact
+* (R *T* d): “…informing, hospitals, schools”
+* (*F* d): influencing organisations and public bodies to try and adapt how institutions work with people
+* (*F* d): adapt environments to help them be more comfortable
+* (*F* d): “help people become more productive and…comfortable in the way they live and work, and in their daily lives.”
+* (**P** g): “I think that unless changes and adaptations are made, we don’t know the full scale of what some people with autism are actually avoiding altogether, and never actually getting access to”
+
+### c) Helping people more generally
+
+* (*F* d): “…those issues do overlap with people who don’t have autism, and so where we can…tease out issues with environments it can only help…to improve everyone’s lives”
+* (R *T* d): “[making] research broader and more efficient and more useful”
+* (*F* d): “[It will] help make the world a better place I think ultimately for everybody”
+* (R *T* d): “The way it’s being run is with mindfulness of inclusivity and empowerment and how do people’s voices get heard, and that to me is hugely vital, for science in general”
+* (R *T* d): “I’m…interested in adjustments to the environment that…enable everyone”
+
+### d) Attracting autistic people/harnessing their value
+
+* (*F* g): “We’re on a journey at Fujitsu learning what it is to embrace neurodiversity…we’ve got to make ourselves more attractive to neurodiverse people, because the value they add to the organisation is absolutely massive”  
+
+### e) Allowing people to be heard
+
+* (**A** d): “It gives people who may not usually have a voice a representation”
+* (*F* d): “…giving a voice is amazing.” 
+* (**A** d): “I can’t think of anything that is dedicated solely to autistic-related research in terms of actually having a platform for that”
+
+### f) Helping educate neurotypical people and remove stigma
+
+* (**P** d): “I’m interested in helping to educate as much as anything, employers”
+* (**A** **P** d): “I think that improving sensory environments is absolutely instrumental to removing stigma in society associated with this condition”
+* (*F* d): “…to be able to share information and really understand what people feel themselves going through”
+* (**A** **P** d): “awareness is really important – understanding”
+* (R *T* d): “we can gather together common themes…but also the nuance of experience, and I think this will help people to make…more sensible adjustments, that aren’t just assuming everyone with autism has the same needs and wants”
+* (*F* d): “I’ve suffered from mental health issues myself, and it’s certainly changed my perception for then understanding what people go through, and I think having this platform to be able to share that information and really understand what people feel themselves going through…I think is vital and will help make the world a better place, I think ultimately for everybody”
+
+### g) Creating connections/community
+
+* (**A** **P** *A* R d): “I believe that [Autistica has] a unique opportunity to facilitate partnerships, including the involvement of autistic people and family members”
+* (R *T* d): “I’m really interested in…trying to find out ways of having people effectively collaborate with each other, so I’m really interested in the discussions around that as well” 
+
+### h) Sharing expertise and personal perspective
+ 
+* (**A** **P** d): “…to give perspective on autism as a parent and wife, and as a lawyer”
+* (*F* d): “…understanding what it is about sensory perception, what it is about our environment we need to understand, or we need to adjust …really excited about this”
+* (**A** **P** d): “…it’s not just expert advice, everyone is…coming from their life experience, from their relative’s experience, and they’re saying, ‘it helped someone, I’m sure it would help others’, so I think a project like this is important” 
+
+### i) Getting suggestions and recommendations
+
+* (*F* i): “I think there was quite a strong preference…to get tips from the platform, i.e. helpful experiences in terms of how people could adjust the environment”
+
+## 2. Experiences of autistic people and their families in their daily life
+
+### a) General
+
+* (**A** **P** g): “…certain environments are off limits to many people with autism because of the sensory implications”
+* (**A** **P** g): “…a lot of the sensory stuff [affects people in the same ways], noise…flashing lights”
+
+### b) Shops
+
+* (**A** **P** d): “Boots, is re-doing a lot of its big stores, and the whole ground floor is now a perfumery…I’m sensitive to perfume, so I’m gonna avoid Boots now”
+* (**P** d): “a lot of big stores the minute you walk through the door you’re bombarded with perfume and things…they make my headaches worse” 
+
+### c) Hospitals
+
+* (**P** i): “…my son had to have a dental operation last year…it was a dreadful experience…the anaesthetist didn’t understand, the staff didn’t understand. He was put in a room with lots of screaming children in the recovery. It culminated in him biting through his tongue, biting through his lip. His sensory overload was huge”
+
+### d) Employment
+
+* (**P** i): took son 2 years to get a job after he graduated, even though he’s brilliant and reliable, because he doesn’t talk enough for interviews, “I think a lot of the time employers have no idea how to approach interviews with people on the spectrum”
+
+### e) Education
+
+* (**P** i): “once [my son] went to university he struggled because we didn’t realise it was the autism, because he also has a disability related to autism, a physical one that also often comes with autism”
+* (**P** i): “the second son with autism struggles a great deal. He’s at university, and it became apparent how challenging that was for him” 
+* (**P** g): “…it’s just so noisy in a tiny classroom”
+* (**P** i): asked for someone to accompany son between classes, “because a small person amongst a thousand odd very tall people, can be quite overwhelming…he had a few meltdowns, and he was sort of hitting out…it wasn’t hitting anybody in particular, it was just – panic”
+* (**P** i): “teachers don’t seem to have any knowledge or awareness of the needs of people on the spectrum”
+* (**A** **P** i): [son was] “…put in a party house this year on campus, and he’d asked for a fridge in his room because he cannot go in the kitchen when other people are around…he wrote and said, ‘Where’s my fridge? I’ve got to store food away in there’…Disability services, who should be aware, wrote back, “…until we find a fridge, please do it”
+* (**A** d): “I got too much support…they just gave me…a teaching assistant for every single classroom…I felt like I really didn’t need it, because it actually just distracted me from work”
+* (**A** **P** d): “it took me several years to convince his [autistic son’s] school to serve plain pasta, so he doesn’t have to explain every time that he has an eating disorder”
+* (**A** **P** i): dealing with students with autism and other disabilities is a lot of work, “I am fully aware, because I have autism and I have children who struggle, I do the extra hours. No other staff member does, and it affects me therefore, because I kind of take on responsibility for all the students”
+
+### f) Communication
+
+* (**P** i): “My son can’t read, write, or speak”
+* (**A** **p** i): “[My son] finds it difficult to talk in a lot of situations like going to the doctors for example, so I have to go with him”
+* (**P** i): “my son can’t… verbalise how [he] feels…whenever you ask him how he is even if he’s got a streaming cold, he always says, ‘I’m fine’” 
+* (**P** i): “…he struggles to talk – he normally texts me or write notes”
+* (**A** **P** *A* R d): “I guess it’s a bit like building blocks…maybe if that person didn’t have elevated anxiety levels because of the sensory environment they might be able to communicate a certain level of need, but then if you put them together [it becomes challenging]”
+
+### g) Misunderstanding and Stigma
+
+* (R *T* i): “…something that has come up a few times is this expectation that if someone is having difficulty…the problem is they’re being difficult or awkward, when…often it’s the environments that we create and the ways that we interact that’s the problem, and I think that’s a really useful thing that hopefully this [project] can help address” 
+* (R *T* i): “this seems…a big theme: people making assumptions, instead of listening”
+* (**A** **p** i): “…people mean well everywhere, they want to do the right thing, but the problem is that, quite often, they don’t have a standard, because they don’t have expert guidance”
+
+### h) Travel
+
+* (**A** **p** d): “I think transport is one of the hardest”
+
+###i) Adaptations and solutions: experiences and suggestions
+
+* (**A** **p** g): “when you integrate sensory adjustments into the environment…you make people’s lives easier, and they can keep certain sensitive information about their condition to themselves, and it empowers them in a big way”
+* (**A** **p** d): “…if you just put it into a standard…[it] loses all the richness”
+
+### j) Listening to individual needs and offering choice
+
+* (**A** **p** g): “sensory inclusiveness, so you offer choice, without forcing the person to explain, and this is so easy, and at the same time it’s of enormous benefit to people, because they don’t have to disclose their condition, they are given the choice anyway”
+* (**A** d): “’I know what I want, I know what I need, can you do this for me, yes or no?’ And then it…speeds up”
+* (**A** d): “just having the flexibility I think’s one of the most important things”
+* (**A** d): “you should be the one to approach [disability services] rather than vice versa”
+* (**A** **p** i): “There’ll be many young people that wouldn’t approach disability services, and not realise that they have to”
+
+### k) Having an “autism hour, or ‘quiet hour’ in busy public spaces
+
+* (**A** i): “…there’s some online backlash…people are saying ‘this isn’t enough’, ‘Why can’t it be like this all the time?’, ‘Why does it have to be background music?’”
+* (**A** **p** i): “there’s specific times that might not be convenient, people have different sleeping patterns and everything, and my son wouldn’t go to them”
+* (**A** d): Would be good to have some quiet times “…at my local library…they have mum and baby groups there, it’s kind of like the main community hub of my town area” 
+* (**A** *A* d): “so the idea of a noisy library is fantastic for me, I would love that… [important to let] people document the different types of experience that they need”
+
+### l) Adaptations in schools/universities
+
+* (**A** **p** d): let people come in either half an hour early or half an hour later
+* (**A** **p** d): everybody used to signing for the register, “so there wasn’t that tumultuous start to the day”
+* (**A** **p** i): “we made loads of different adaptions, and it really worked – for all the children… I think to be honest we saw that the concentration levels of all the children improved, with just those adaptions in place”
+* (**A** d): “they could install sound fields to improve auditory processing for some children”
+
+### m) Network or community of volunteers 
+
+* (**A** d): “we went to Germany recently, to look at some programmes they were doing to educate people about the holocaust and Nazis and fascism, and there was one…voluntary group…going to schools and training the school children in awareness, so it could be [done] with this data”
+
+### n) Education
+
+* (**P** i): “…they [son’s university] were just so helpful, and he stayed in halls the whole time, because he couldn’t cope with a party house”
+* (**A** d): “the support services [at university] are actually pretty decent”
+
+### o) Hospitals
+
+* (**P** i): Experience of autistic son’s dental operation:
+•	best interests meeting beforehand
+•	learning disability nurse [to] pass information on
+•	lights all dimmed
+•	autistic son only one in the recovery room
+•	autistic son given a pre-med 
+•	things being explained clearly/factually: “the anaesthetist understanding not to talk to him like a baby”
+•	allowing him to lie on the bed and then have the same bed wheeled in
+•	“this was the same operation, but with a few moderations – no trauma, nothing - and it was a great experience” 
+* (**P** d): “I recently had a knee operation…I was told every step of the way exactly what was going to happen, but if I wasn’t…it’s quite overwhelming even for a neurotypical person…”
+* (**A** *A* d): [Being treated for a broken foot]: “I was very impressed…they knew I was autistic and they did give me support”
+
+## 3. Platform Design
+
+### a) General
+
+* (R *T* d): “make the user interface as broadly accessible as possible”
+* (**A** d): “having…one place where you can find everything…and the potential to have that expand, I think is really helpful.” 
+* (**A** d): privatise where your location is for the public site and research, but use information for individual to get location specific pop-ups
+
+
+### b) Non-verbal means of inputting information
+
+* (**A** d): “…having the option to…upload photos, or pictures, or voice recordings of people.”
+* (**P** g): “A lot of people do communicate quite visually, or understand things visually, so that would be useful, if people could have pictures” 
+* (**A** **p** d): “communication with pictures, voice to text interface” to improve accessibility 
+
+
+### c) Filters for different kinds of user
+
+* (**A** d): “that would be good…if you’re an autistic person who wants someone to relate to…you can always filter it through to see personal perspectives, whilst…parents might be looking for a different thing” 
+* (R *T* d): “[maybe there is an] opportunity in this for autistic people and parents to empathise with each other through sharing experience…if you segregated the responses, it would prevent that from happening”
+* (**P** d): “you wouldn’t have to segregate them… you could just… have a drop box where people choose whether they’re parents, people with autism, teachers, employers…”
+
+### d) How should we ask the research question? 
+
+* (**A** d): “…[make] sure the question’s not broad”
+* (**A** d): “…remind all people that this isn’t the experience of all of us, it’s just the experience of a good handful of us”
+* (R *T* d): “we’ll probably ask people to share a lot, and then it’s on the researcher, to…tease out the sensory processing aspect”
+* (R *T* i): “I think the only thing that I’m slightly worried about is if people feel that the experience that they’re sharing that is not related to the sensory processing doesn’t get the same level of attention, in the published research… [solution is]…setting expectations”
+* (**A** **p** d): “I think that when we collect several experiences for one particular environment, [researchers] can actually analyse that environment, without [participants] actually going into sensory analysis” 
+
+## 4. Moderation
+
+### a) General
+
+* (R *T* d): “[moderation] is purposefully a lot of work, in order to maintain a safe and inclusive space”
+
+### b) Delayed response
+
+* (*F* d): “[how] important is the immediacy of that information? Because, if everything is going to go through the moderation process, then maybe the salience of…advice is lost.” [potential solution multiple input channels, select for immediate response, free text otherwise]
+* (R *T* d): there are other platforms, such as social media, for immediate responses
+* (R *T* d): “I think we are going to have to do a due diligence of at least at the beginning, reading everything that’s going to be made public to make sure it’s not…insulting…or identifying…so there probably is going to have to be a time gap”
+* (**A** **P** i): “…it’s a very high standard to review everything, and give them advice, and do all of that, it might become unworkable” 
+
+### c) Who should moderate? 
+
+* (R *T* d): “…one thing that we’ll almost certainly do is have a diverse group of people moderating those public posts, so I think there’s a little bit of a safeguard”
+
+### d) Communication
+
+* (R *T* d): “an option is for the moderating team…to send a message back to the person that uploaded it to say, ‘these are the things that we’re concerned about, it doesn’t violate our code of conduct… we just wanted to check in with you… have you thought through this, this, and this” 
+* (**A** **P** d): “…having you bounce it back and say, ‘have you thought about that’, would make me think, ‘Oh god, I’ve done it again, I’m really bad, I just can’t behave normally’”
+* (R *T* d): “that’s so important that whatever we design doesn’t make people feel like they’re doing something wrong by expressing themselves in that way”
+
+### e) Community Response
+
+* (**A** **P** g): “when you talk about moderation and basically exclude certain facts, you know, there could be a backlash from your community saying they’ve been misrepresented, because you’ve excluded certain facts”
+
+### f) (**P** d): Link to Facebook page where unmoderated messages could be posted
+
+* (** P** *F* d): “being directed to social media then loses the anonymity we’ve got on the platform, because if people then went on to post something about it on Facebook or on Twitter, then you’re identifiable”
+
+### g) What should we moderate for?
+
+* (**A** *A* d): being identifiable through multiple posts
+* (**A** d): Legal problems if organisations or companies are named
+* (**P** d): Accidentally including incriminating information
+* (R *T* d): “…probably the moderators would just say, ‘no, we’re going to accept it, we’re going to keep it for research purposes, but we’re not going to make it public’”
+* (**P** i): sharing inappropriate (or socially awkward) information
+* (**A** **P** g): people who know the individual being able to identify them
+* (**A** **P** d): “supposing…my husband goes on and…works out that it must be me… there’s still implications there”
+* (R *T* d): “there’s that whole dimension of other people that you might know personally, reading your stories.”
+* (R *T* d): “I do think that probably the moderation process is almost certainly going to moderate out of the public one, but keep in for research if it’s consented, anything that talks about anyone else in a way that it could be identified”
+* (**A** **P** d): “I think a moderator to look at things that don’t have consent in particular, and who probably should be someone autistic, and who could remove any of those things that could do damage”
+
+### h) What would help?
+
+* (**A** d): “if you were concerned about the welfare of someone… a section if you need advice or if you need help”
+
+### i) Allowing people to comment
+
+* (R *T* d): “I think there’s almost no chance that we’ll allow people to comment on posts
+* (**A** g): “That could give people a lot of anxiety”
+
+
+## 5. Representing others
+
+### a) General
+
+* (R *T* d): “we want to make the data set as broad as possible and make the process as inclusive as possible, and certainly not exclude anyone because they have challenges, and on the other hand we take consent and agency really seriously, and we think everyone should have a right to express themselves in a way that they want - so these are the two sides of the coin.”
+
+### b) Important to give everyone a voice
+
+* (**P** d): “I am his voice, so I’m trying to represent young people like him, because the spectrum is large isn’t it?”
+* (**P** d): “I feel quite strongly that we should be able to share a story, because…my son’s non-verbal, so his behaviour displays a lot of how he feels, and as his Mum I feel I understand him pretty well, and I would hate for people’s voices not to be heard because they can’t express it”
+* (**P** i): “…even if [some autistic people] are eloquent with people they know well, they may want someone else to speak on their behalf on the platform, if they can’t do it themselves as well”
+* (**P** i): “my son can’t consent, I know how hard he struggles to communicate…and I do feel that he would want to be included”
+* (**P** d): “unless we do include people who are non-verbal or not or minimally verbal, they’re going to continue to be a neglected group.”
+* (R *T* d): “…although it is not the easiest thing in the world to give consent to tell stories about other people, I think it’s really important that we try…to come up with a process for what that looks like, and we will brainstorm that, and we’ll iterate it a few times over”
+
+### c) Concerns and complexities
+
+* (**A** d): Would be good to have some quiet times “…at my local library…they have mum and baby groups there, it’s kind of like the main community hub of my town area. 
+* (**A** *A* d): “so the idea of a noisy library is fantastic for me, I would love that… [important to let] people document the different types of experience that they need”
+
+### d) Distortion
+
+* (**A** d): “…there could be people who maybe exaggerate or post stories about other people”
+* (**A** d): “there’s always gonna be a personal bias in this because it’s coming from one perspective”
+* (**A** **P** d): “…distortions are very important, because we want raw data…it needs to be given even to non-verbal people to deliver feedback through pictures, through other ways…the more opportunities [for] people to express them[selves] directly the better. We want…as unbiased, authentic information as possible”
+* (**A** **P** d): “…you have secondary source and that’s a distortion”
+
+### e) Consent
+
+* (**P** d): “my son doesn’t talk, but would, can consent”
+* (R *T* d): “…it’s not just whether someone can be identified, and there’s a legal requirement, but also an ethical question, is this the right thing to do?”
+* (**A** **P** d): “…the problem is that when you tick that box was the consent informed, or did the person just say ‘yes’?”
+
+### f) Who could be trusted to represent somebody else?
+
+* (**A** d): “depends how close they [the person doing the reporting] are…as long as it’s…a close parent, or guardian, or sibling, someone…the person themselves could trust.”
+* (**P** d): “I’ve got lots of experiences from my work, I wouldn’t be comfortable sharing those, because they’re not my children, so I would only share the experience of my child”
+* (**P** d): “…make it very careful in terms of who got to share whose experiences [e.g. parents] …not just general”
+* (**P** d): “I wouldn’t feel comfortable sharing experiences even if I anonymised about someone else’s child”
+* (**A** **P** R *A* d): “…there is now a group of older autistic adults, who you know, may not be in a position for their parents to be able to report for them”
+* (**A** **P** d): someone with credentials, such as a Welfare Deputy Officer.
+
+### g) Community Response
+
+* (**P** d): “it’s political, you need to think about your audience and feedback…from people, backlashes, because  the autistic community can get quite nasty, and apologies to anyone here but… there are particular people that think that parents do not have a right to say anything about their children, and they get really nasty on twitter about it”
+* (**A** **P** R *A* d): “…in terms of people who might have concerns from the autistic community… show that we’ve taken steps to make sure that this is accessible as possible…there are limitations to the research approach – there are limitations to self-reporting, because we don’t understand ourselves very well either…and we can’t let perfection be the enemy to the good here”
+
+### h) Guidance for representing others
+
+* (**P** d): “…take away the emotive from it…just record the factual side of it”
+* (**P** d): “…cut out your own emotions and comments”
+
+### i) Suggestions for processes
+
+* (**A** d): Guidelines: “a set kind of guidelines – nothing too specific in case they sort of need to express themselves in a certain way - ‘I’ve read or understood the following agreements to posting’”
+* (R *T* d): [have a] “process whereby we would give some guidance to say - this is how you would best share someone’s experience without distorting it, this is how you represent someone well…”
+* (**P** d): Authentication process: “if you’re a parent or a sibling or a close relative, you could even have another person countersign to say…they believe that to be the truth as well”
+* (**A** d): Caveating submissions: “maybe they would have to state, ‘I am somebody’s mother, and this is how I feel, this is what I feel’…obviously if you can’t consent or offer information then it’s clear that it’s actually what you feel as much as you know that child”
+* (**A** **P** R *A* d): Hybrid: “…give some information…supported by someone else to explain some of the context”
+
+## 6. Data Management
+
+### a) General
+
+* (R *T* d): FAIR principles for data use: findable, accessible, interoperable, and reusable 
+
+### b) Agency
+
+* (R *T* d): “we’ll almost certainly have three options, one that says you can use it and no-one else can, one that says if this…governance panel, thinks that it’s a reasonable application from a project that’s value aligned, then I’m opting in… the third option, that will be, “I want to be contacted on every individual basis’” 
+* (R *T* d): “[a] goal of the project is to allow people to understand a little bit more about the agency over their data”
+
+### c) Anonymity
+
+* (R *T* d): “we imagine that…it will be anonymous and we’ll take out any identifying data”
+* (**A** **P** d): “if someone records for someone [else] the way…around it is anonymisation… removing any personal identifiers”
+
+### d) Informed consent
+
+* (R *T* d): “I think we’ll have to put quite a lot in place to trust that the individual person who was entering information has read the consent form, has checked through those boxes, I think there’s quite a lot of design around making that extremely clear”
+* (**A** d): [example of a good terms of conditions]: “…a fake box where if you ticked it would then stay on the page for ten minutes and you would have to read it”
+* (**P** i): “some autistic people can be a little naïve, and sort of overshare things”
+* (**P** g): “…by sharing information, if prospective employers look at it, that could affect [autistic people’s] prospects”
+* (**A** *A* g): “I think probably quite a lot of the community would be keen to repost”
+* (**A** *A* d): “I slightly worry I suppose if it’s an individual profile that is posting a lot in a particular area, does that make it kind of identifiable?””
+* (R *T* d): “…you would absolutely be allowed to have a profile that would include no photo, no name, just a made-up name associated with the account, you wouldn’t need to make any of that information public.”
+* (**A** **P** d): “[if the question is too general], we’ll lose sight of the sensory aspects, it’s sensory, let’s keep it to sensory”
+
+### e) Communicating consent
+
+* (R *T* d): “the really important thing… [about consent] is the clarity and the purpose…and communicating what it means in a way that is not a massive, massive block of text that’s really overwhelming”
+* (**A** **P** d): “…as a data controller, you actually have to be very clear about your purpose in collecting the information”
+* (**P** d): make sure the consent form is not too long
+* (**P** d): put the consent form in fairly simple language
+
+### f) Changing consent
+
+* (R *T* d): “I think [the ability to withdraw data] is a huge feature around…the ethics of the data management.”
+
+### g) Design
+
+* (**A** **P** d): “…the whole of your platform should be designed to protect privacy”
+* (**A** **P** d): “you need to collect just enough according to your purpose”
+
+### h) Which groups or organisations should learn from the data? 
+
+* (**P** d): shops
+* (**A** **P** d): schools
+* (**A** d): the NHS 
+* (**A** d): GP surgeries, waiting areas, hospitals
+* (**A** **P** i): “for my son, in particular trying to go along to the doctors or a hospital appointment is an absolute nightmare”
+* (**A** **P** R *A* g): “NHS England, in their 10 year plan, have named autism and other disabilities one of 4 clinical priorities…I think there is an opportunity here to actually do something that does make a difference in GP services and hospitals, because at the moment politically, they’re listening”
+* (**A** **P** d): architects and designers
+* (**A** **P** d): “…you need someone like that involved who can pull all the data together and get it to be used”
+(A, d): “possibly even autistic, or people who closely associate with autism, architects and designers…who has…interior insight”
+* (**A** d): airports and train stations
+* (R *T* d): libraries
+
+## 7. Contribution channels
+
+### a) General
+
+*  (*F* d): there should be multiple input channels 
+* (R *T* d): “hopefully people who aren’t able to come to the focus groups, are not only heard by [researchers], but actually incorporated into a body of evidence and data that can be used by other people for the purposes of understanding a little better what the priorities are from the autistic community.”
+* (**A** d): “if there’s a decision-making process. which you need a quick answer to, maybe a Twitter poll”
+
+### b) Focus Groups
+
+* (**A** d): “…being part of this kind of focus group…gives people who may not usually have a voice a representation”
+* (R *T* d): helpful to have thoughts written down 
+* (R *T* d): “…one of the interesting things about the focus groups is that you lead the discussion by the question that you ask and the direction that you take”
+
+### c) Personal Email
+
+* (R *T* d): “we just can’t use it for research, but if you’re confused about any of the other ways of joining in, you can just email me, and I will help you with whatever you need help with.”
+
+### d) Mailbox
+
+* (**A** **P** d): this would be the easiest way of sharing the project and getting people to join in
+
+### e) Google Forms Survey 
+
+* (**A** d): how can we be sure what’s put in there is authentic 
+* (**P** g): it would be useful to have pictures for those who contribute visually
+* (R *T* d): allows people to contribute who can’t be here in real life 
+* (R *T* d): it is always open, you can contribute at any time
+* (R *T* d): “we’ve received, like quite a lot of feedback in the past month that it’s really confusing”
+
+### f) GitHub
+
+* (R *T* d): “…you can also take part. via. GitHub, which is where you can just come and publicly and in an identifiable way you can put your priorities and your goals and the next steps of the project in there”
+
+## 8. Ways of working
+
+### a) Diversity and Inclusion
+
+* (**A** d): place where volunteered, “had a programme involv[ing] facilitations, and chats…we’d have a special guest who might be a psychologist, or a professor, or sometimes a doctor, and it would all be kind…topics to do with relevant issue,…finance, bullying, home issues, social issues…having an equivalent on the forum could…attract different groups.”
+* (R *T* d): “if you do not have fair equity, diversity, and inclusion processes, then the people who drive the research and who choose what is going to be done with the money for the research is a very, very biased group”
+* (R *T* g): Who might not be able to take part and possible solutions?
+* (**P** d): people who are blind
+* (**A** **P** d): assistive technology could help
+* (R *T* d): make sure that the text that you use and where you lay things out on the page can be read by a screen reader.
+(F, d): integrating more with virtual assistants like Alexa or Siri
+* (**P** i): “…my mum couldn’t use the internet or whatever, but she used her Alexa, it was her best friend in the end”
+* (**P** i): elderly people with autism, that aren’t as tech savvy
+		* (**P** d): leaflets in libraries and surgeries 
+* (R *T* d): “those are good ideas about how you would communicate the project, but not collect their experiences without them going online” 
+* (R *T* d): library sessions where people with trained mentors who could help them join in 
+* (**A** **P** i): they might be tech savvy, but they might not have access
+* (**A** **P** g): “recent reports show that elderly people and children don’t use the internet not only because they don’t know how, but also because they are concerned there will be some scam”
+* (**A** **P** d): people from lower socio-economic groups
+(T, R, d): technological upskilling could offer compensation for time/motive to join project
+*  (*F* d): people who are not Western and European
+* (R *T* i): came up in previous focus groups that maybe the platform itself should be available in other languages
+* (R *T* d): “I’m happy to be led by the community… [but] we’re already doing so much that starting to go into other languages is really tough”
+(F, d): not just the language aspect, also the lived experience
+* (R *T* d): “we can say that it’s a global platform, because it’s on the web, but if it’s not really accessible to every member of the globe, then we shouldn’t be calling it a global platform”
+* (R *T* d): realistically, we will be using Autistica’s Discover Network, of around 5,000 people who are all UK based, initially 
+* (R *T* d): “don’t try to get lots of kudos by showing off to an international audience…if it’s really only accessible for English-speaking countries”
+(P, A, d): “…for the lived experience, and also…from a research perspective, comparing different countries…would be a great project”
+* (**P** d): People from different regions
+* (**P** i): “…people living in London will have totally different experiences to people in Dorset, or in a farming district”
+
+### b) Online reimbursement
+
+* (**A** **P** d): “…in some ways it might be slightly discriminatory to people who can’t work because …they’re finding it quite hard to live anyway”
+* (R *T* d): “I think that it’s a really important problem, that we don’t pay people, and I don’t have good solutions for how to fix it” 
+* (R *T* g): “…given how much of a general problem it is for autistic people, that there is so much discrimination in the workplace…that there’s this huge institutional bias often… reimbursement is something to think super carefully about”
+* (R *T* d): “I think it’s bad for research to only hear from the people who have time, and space, and…the finances to be able to take part.”
+* (R *T* d): Open Source] is great if you are in a privileged position such that you can give away everything for free and you can give away your time for free, but the status quo is… problematic”
+* (**A** g): “if it’s free people might sort of click through it rather than actually reading through the questions… if they know they’re not being paid for their time”
+* (R *T* d): the reason why we don’t pay people is because it’s pretty difficult to do, and the main, the main difficulty is…related to this holding personal information…your bank account details are really important”
+* (R *T* d): “I hope that there will be [user testing available over] Skype or some sort of video conferencing, and those will be paid”
+*  (*F* d): basic attention token as means of reimbursement 
+*  (*F* d): “based on your attention on the page, it’ll be able to reward you with a particular crypto-currency - you put cryptocurrency for research [in a pot], and then people…draw from the pot as a reward for their attention to that page”
+* (R *T* d): I’ve actually got a lot of dislike for cryptocurrency for a lot of different reasons
+* (**A** d): Amazon vouchers
+* (**P** d): “I…do quite a few different things, where they may monitor my phone or what I’m listening to on the radio and then they pay me in Amazon vouchers”
+* (R *T* d): “I think it’s a really good point actually, because all you would need is an email address for the project itself we’re going to have an email address”
+* (**A** **P** d): prize draw
+(T, R, d): “I think that’s wildly unethical… I think it’s much more honest to say, look, we’re not going to pay you for your time to fill in this questionnaire, and this is how long it’s going to take, and you can make that decision”
+* (**A** **P** d): choice of charities for people to donate to
+* (**A** **P** d): “I think that’s still discriminatory…if you’re struggling to make ends meet”
+* (**A** **P** d): “[Rationale that] you’re over-budget, and these people are so motivated to do it that they’ll do it anyway…that’s unethical”
+* (R *T* g): “I do think there may be a group of people for whom that is motivating…I don’t think that solves the problem of exclusion of people who don’t have the financial means, but I do think it’s interesting”
+* (R *T* d): offer a way for people to get in touch and say if they need to be reimbursed
+* (**A** **P** d): “it’s sort of like an honesty book”
+* (**A** **P** d): take the platform to a place such as the NHS where it would be accessible to people, so they don’t have to access it themselves through the internet
+* (R *T* d): “I think it’s definitely wrong that you would pay people by the amount of time they spend on the page, and I don’t know how you would quantify an appropriate amount of time for somebody to have spent, I don’t know, years of their life thinking about this, vs…slinging down a couple of comments for five minutes”
+
+### c) Openness and Transparency
+
+* (R *T* d): “…all research should be as open as possible, and as closed as necessary”
+* (**A** g): “[make] sure the guidelines are short, sharp, get straight to the point, maybe language type…because some people on the spectrum may be confused by certain terminology such as metaphors and simile”
+* (**A** **A** d): community trust: “I think from a community trust point of view, it’s really good to be transparent about why you want the data, but also why you don’t want the data”
+* (R *T* d): “one of the things that a lot of people thought that we might do with the data was sell it, and that’s definitely not what we’re planning to do with the data, but I think it is useful to be really explicit and upfront about the reasons and motivations, and limits of what we would do”
+* (**A** d): keeping people informed
+* (**A** d): constant updates
+* (**A** d): keeping people informed when there are collaborations with other organisations
+* (R *T* d): “we definitely will do blog posts, videos, online discussions”
+*  (*F* d): cartoon and drawings perhaps explaining the concept of the back end and the application, “something that explains it in layman’s terms might be useful”
+* (**A** **P** d): communicating project
+* (R *T* g): large scale communication will be further down the line: “I think we need to be clearer about what the project is before we communicate it to lots and lots of people”
+* (R *T* g): participants invited to share survey and sign people they know up to the mailing list, but not big public launch until pathways clearer
+* (R *T* g): “there’s a lot of stuff that we need to action and make more accessible first”
+* (R *T* g): no large social media or flier campaign until there is more clarification
+* (R *T* d): promotes reproducibility: “…the key thing for me that really motivates me around reproducibility is that a) Reinhart and Rogoff did not intend to mislead, they didn’t mean to make a mistake, so they had no way of going back and checking…and, it’s very, very rare in academia at the moment and the way that we do scientific research, that anybody checks”
+* (R *T* d): it can get be really hard to, “access…data and figure out what had gone wrong”
+* (R *T* d): “most of the reasons why things aren’t reproducible are the human elements of them”
+* (R *T* d): “why would somebody share their data, or share their code, that accompanied their research, because someone might find that they’d made a mistake, and it is definitely the case that it is the correct thing to do to have people find those mistakes”
+* (R *T* d): “you should be able to get generalisable evidence, before you should be allowed to, for example, make government level or individual person-level decisions about them”
+* (R *T* d): …I think it is unethical to collect really, really valuable datasets and not make them available for future use or potentially for reproducible aspects
+* (R *T* d): having access to data is really important, and having access to the processes and to the things that have been done to that data or with that data are also really important
+* (R *T* d): all research should be as open as possible, and as closed as necessary
+*  (*F* d): “I’m a big advocate for open source, I think it’s absolutely amazing for verifying the code base to make sure it’s secure”
+*  (*F* g): “you may have people who take the branch maliciously and adapt the project maliciously to gain information in a malicious way”
+* (R *T* g): “I don’t know why people would…I think the risk is reasonably low”
+* (**A** **P** d): “you wouldn’t have access to the source code, but because it’s open source, people can copy it”
+* (R *T* d): “…the information needed to authenticate the database itself is private, so there’s a whole bunch of…private security stuff that happens in the background.”
+* (**A** **P** d): “…as soon as it’s on the internet, anyone could copy any of it…not legally, but they could”
+* (R *T* d): although you can’t stop people from [copying public information from the website], you definitely can stop academic researchers from publishing it”
+* (R *T* d): “I do a lot of work around open source development, and these are three principles that I try and work through – that every aspect of the project should be accessible and clear, it should be easy to understand; that the work should be easy to adapt, reproduce and spread, so it’s designed from the beginning to be shareable, and that is important to relate to the sort of responsibility you have for keeping personal data private, and that there is a participatory and inclusive aspect”
+
+
+
+

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -5,7 +5,7 @@ These summaries have been circulated to all participants to offer them the oppor
 Based on the feedback receieved, none of the content was requested to be changed, but the format was modified.  
 
 * [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
-* [24th September 2019](#date-24th-september-2019)
+* [24th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-24092019)
 * [04th October 2019](#date-04th-october-2019)
 
 ### Key

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -4,7 +4,7 @@ This file contains summaries and quotations from focus group sessions concerning
 These summaries have been circulated to all participants to offer them the opportunity to remove or modify their comments if they wish. 
 Based on the feedback receieved, none of the content was requested to be changed, but the format was modified.  
 
-* [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/new/master/community-recommendations#citizen-science-focus-group-18092019)
+* [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
 * [24th September 2019](#date-24th-september-2019)
 * [04th October 2019](#date-04th-october-2019)
 

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -801,7 +801,7 @@ First step (currently) is creating an Open Humans account:
 * (**P** d): “It was narrow, but that kind of thing can be quite useful I think” 
 * (**A** g): “Question 1 could be: ‘please look at this prototype platform’, and then obviously that would be self-contained in terms of what the platform’s about, and then you could give people an opportunity to say whether this was along the right lines, whether it needed tweaking, and then you would know that you were getting what you were asking for”
 
-## l) Presenting Experiences
+### l) Presenting Experiences
 
 * (R *T* g) “there’s two different points here, one is being able to browse other people’s experiences, and be able to learn from them and see them, and find ones that are similar”
 * (**A** d): Search box for experiences
@@ -908,17 +908,17 @@ First step (currently) is creating an Open Humans account:
 * (**P** d): put links to fora for discussion in code of conduct 
 
 
-### 5. Representing others
+## 5. Representing others
 
-## a) Important to give everyone a voice
+### a) Important to give everyone a voice
 
 * (**P** d): If you could not report publicly on behalf of others: “my son’s experiences would never be heard”
 
-## b) Consent
+### b) Consent
 
 * (R *T* d): “It’s extremely difficult to figure out whether it’s possible to consent to sharing somebody else’s experience…my gut feeling is that, if people want to, I think we could accept if it’s for research, but that data will not be made public for any reason”
 
-## c) Community Response
+### c) Community Response
 
 * (**P** g): danger of creating controversy and public argument
 * (**P** i): “you will get parents on the one side who’ll say, my child is as successful as he or she is thanks to ABA, then on the other side you get, I am suffering deeply from PTSD – post traumatic stress disorder – because of ABA”
@@ -927,28 +927,28 @@ First step (currently) is creating an Open Humans account:
 * (R *T* i): “some of the ways that parents sometimes characterise their autistic children can be upsetting to autistic people, and therefore might make it a less welcoming place”
 * (**P** i): [examining example of potential controversial comment]: “’My tip is, this kid is trying to control you, and he needs to understand that this isn’t how the world goes, so be persistent, don’t take no for an answer, and all that kind of stuff’”, do you see what I mean, and you go… ’also understanding parent’s experiences will be valuable’, and they’ll go – ‘oh, it was hell, it was hell, he screamed and he punched and he did all these things’, I’m saying he, could be she, and you go, ‘yeah, I know, but that’s your experience of your son’s, daughter’s really bad sensory experience here’, but be mindful that there are autistic people who will read it, and it’ll be their experience they’ll be thinking about, even though your experience is entirely valid, because it is hell, when you’re trying to get somewhere, and your child has their arm wrapped around your neck and they’re pulling your hair, and often you kind of go, like, and this is a [tall] bloke, and you’re a little person, and everyone’s looking at you going oh, woah, yes, but actually his experience is probably worse than mine.” 
 
-### 6. Data Management
+## 6. Data Management
 
-## a) Agency
+### a) Agency
 
 * (R *T* d): “part of the point of the project is that people have agency”
 * (R *T* d): “the whole point of the Open Humans project…is to empower people to have control over their own data, and that is essentially what we’re doing here”
 
-## b) Changing consent
+### b) Changing consent
 
 * (R *T* d): For me…it’s very important for people to be able to change their mind
 
-## c) Which Groups or Organisations Should Learn from the Data?
+### c) Which Groups or Organisations Should Learn from the Data?
 
 * (*F* d): the department of transport…”so they can adjust transport for London with regards to tailoring it and assisting people with autism”
 
-### 7. Contribution Channels 
+## 7. Contribution Channels 
 
-## a) General
+### a) General
 
 * (R *T* d): “the problem with options is there’s lots…which can be complex, so, this is what we’re currently figuring out”
 
-## b) Focus Groups
+### b) Focus Groups
 
 * (R *T* i): “I think you can feel from the focus of these discussions that it’s really hard to be part of a project this early on, there are so many options, and there are so many unanswered questions”
 * (R *T* d): “So that’s exactly what we need in fact, that’s why these sessions are so useful, because you’re the pioneers of different solutions, and you can tell us this could be better, and then we can make it better”
@@ -957,13 +957,13 @@ First step (currently) is creating an Open Humans account:
 
 * (R *T* d): “that’s a private communication, and so we can’t use the comments for our research”
 
-## d) Mailbox and newsletters
+### d) Mailbox and newsletters
 
 * (R *T* d): “So again, we were iterating the design of the letters, so the first one we sent people said was slightly too much information and too many options, so for the next one we made it simpler and specific in terms of what we were asking for.”
 * (R *T* d): “So if you reply to this it only goes to [redacted] and me, it’s not a general discussion, but you can at least stay up to date and we’ll try to send monthly updates.” 
 * (R *T* d): “…it’s very vague, kind of blue sky, but there will be a time when there’s a fully functional platform and we’ll need as many people as possible to try and use it”
 
-## e) Google Forms Survey
+### e) Google Forms Survey
 
 * (R *T* d): “…if we copied and pasted it into this box, then we could use it for research”
 * (R *T* d): “I think it’s really important that something like this exists, we just need to do another pass through making it clearer about what the pathway is when you get to it”

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -10,36 +10,36 @@ Based on the feedback receieved, none of the content was requested to be changed
 
 * [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
 
-1. Value of project and motivations to take part
-2. Experiences of autistic people and their families in their daily lives
-3. Platform design
-4. Moderation
-5. Representing others
-6. Data management
-7. Contribution channels
-8. Ways of working
+1. [Value of project and motivations to take part](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#1-value-of-project-and-motivations-to-take-part)
+2. [Experiences of autistic people and their families in their daily lives](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#2-experiences-of-autistic-people-and-their-families-face-in-their-daily-life )
+3. [Platform design](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#3-platform-design )
+4. [Moderation](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#4-moderation)
+5. [Representing others](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#5-representing-others)
+6. [Data management](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#6-data-management)
+7. [Contribution channels](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#7-contribution-channels)
+8. [Ways of working](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#8-ways-of-working)
 	
 * [24th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-24092019)
 
-1. Value of project and motivations to take part
-2. Experiences of autistic people and their families in their daily lives
-3. Platform design
-4. Moderation
-5. Representing others
-6. Data management
-7. Contribution channels
-8. Ways of working
+1. [Value of project and motivations to take part](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#8-ways-of-working)
+2. [Experiences of autistic people and their families in their daily lives](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#2-experiences-of-autistic-people-and-their-families-in-their-daily-life)
+3. [Platform design](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#3-platform-design-1)
+4. [Moderation](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#4-moderation)
+5. [Representing others](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#5-representing-others-1)
+6. [Data management](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#6-data-management-1)
+7. [Contribution channels](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#7-contribution-channels-1)
+8. [Ways of working](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#8-ways-of-working-1)
 
 * [04th October 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-04102019)
 
-1. Value of project and motivations to take part
-2. Experiences of autistic people and their families in their daily lives
-3. Platform design
-4. Moderation
-5. Representing others
-6. Data management
-7. Contribution channels
-8. Ways of working
+1. [Value of project and motivations to take part](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#1-value-of-project-and-motivations-to-take-part-2)
+2. [Experiences of autistic people and their families in their daily lives](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#2-experiences-of-autistic-people-and-their-families-in-their-daily-life-1)
+3. [Platform design](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#3-platform-design-2)
+4. [Moderation](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#4-moderation-)
+5. [Representing others](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#5-representing-others-2)
+6. [Data management](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#6-data-management-2)
+7. [Contribution channels](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#7-contribution-channels-2)
+8. [Ways of working]()
 
 ### Key
 
@@ -72,7 +72,7 @@ Based on the feedback receieved, none of the content was requested to be changed
 
 ### Helping autistic people and their families
 
-* (F d): “I’m interested in the enabling factors of the project”
+* (*F* d): “I’m interested in the enabling factors of the project”
 * (**P** F d): “I have a [teenage] son with Asperger’s, and I’m really excited by all the prospects the work is going to have to make his life a lot easier”
 * (**A** d): “I’m just really interested in helping other autistic people with sensory processing differences”
 * (**A** d): “I dropped out of uni mainly because of sensory issues that I had at the time, so that’s why I’m interested in this”

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -2,11 +2,44 @@
 
 This file contains summaries and quotations from focus group sessions concerning the Autistica/Turing citizen science project, which was held with members of Autistica's Insight group, Fujitsu, The Turing, and Autistica on the 18th and 24th September 2019, and 4th October 2019. Quotations have been shortened or summarised, labelled according to the speaker, and all depersonalising information has been removed. 
 These summaries have been circulated to all participants to offer them the opportunity to remove or modify their comments if they wish. 
-Based on the feedback receieved, none of the content was requested to be changed, but the format was modified.  
+Based on the feedback receieved, none of the content was requested to be changed, but the format was modified.
+
+## Contents
+
+* [Key]
 
 * [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-18092019)
+
+1. Value of project and motivations to take part
+2. Experiences of autistic people and their families in their daily lives
+3. Platform design
+4. Moderation
+5. Representing others
+6. Data management
+7. Contribution channels
+8. Ways of working
+	
 * [24th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-24092019)
+
+1. Value of project and motivations to take part
+2. Experiences of autistic people and their families in their daily lives
+3. Platform design
+4. Moderation
+5. Representing others
+6. Data management
+7. Contribution channels
+8. Ways of working
+
 * [04th October 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#citizen-science-focus-group-04102019)
+
+1. Value of project and motivations to take part
+2. Experiences of autistic people and their families in their daily lives
+3. Platform design
+4. Moderation
+5. Representing others
+6. Data management
+7. Contribution channels
+8. Ways of working
 
 ### Key
 

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -552,3 +552,433 @@ want that to be there anymore”
 * (*F* d): “I’ve taken a fork off of the Alan Turing repository and we kind of have our own dedicated branch for this interface piece of work that we’re going to be involved with, but that’s also public”
 * (R, *T* d): “the benefit of building it in an open source way is that if we aren’t able to do [a feature like translation] … another community might be able to, and we’d be able to facilitate that.”
 * (*F* d): “given the fact that…the GitHub repository is open to anyone in the world who is interested in contributing to the project…in Fujitsu we are mobilised, with our talented developers, to tap into this” 
+
+## CITIZEN SCIENCE FOCUS GROUP 24/09/2019
+
+## *Thematic Summary*
+
+## 1. Value of project and motivations to take part
+
+### a) Helping autistic people and their families
+
+* (R, *T* d): “I think there’s a possibility that we can really make changes to environments in a way that will improve things for autistic people, so I’m very excited to be here.” 
+* (*F* d): “I would like to be able to gain a lot of information and at least help my sister and my other siblings and help the [autistic] children in my family.” 
+* (R *T* d): “guidance for public spaces…with actions that they could take to make their spaces more accessible”
+
+### b) Helping people more generally
+
+* (R *T* d): “giving people access and management over their own data and the purposes that it’s used for is one of the things that I’m very interested in”
+* (*F* d): “I [have] a real passion for responsible business in general, and making a difference to the communities that we serve”
+* (**P** g): “it’s empowering to people, to give them something that they do have to contribute”
+
+### c) Research
+
+* (R, *T* d): “To…survey as broad a swathe of the autistic community as possible, in order to pull out common themes of experiences”
+* (**P** d): “because I’m a budding researcher, yes, of course, I’m highly motivated”
+* (R, *T* d): “to break autism research out of just being in a lab”
+
+### d) Allowing people to be heard
+
+* (R, *T* d): “I’m really fascinated by this project because it’s participatory, the inclusion of people in the design”
+* (**A** *A* d): [bringing] “autistic people and family members into research, and other things which gets their voices heard”
+
+### e) Helping educate neurotypical people and remove stigma
+
+* (**P** d): “I’ve always been interested in what makes [my son] understand the world, and how to make things easier for him
+* (*F* d): “I’m really looking forward to listening to people”
+* (*F* d): “It’s been fantastic for me…to get such a better understanding and an insight into [autism]”
+* (*F* d): “I can then help to share those messages within Fujitsu to employees too and raise that awareness…to educate people within Fujitsu and help to support, which is great”
+* (R, *T* g): “…if you already know autistic people you can learn quite a lot from having those conversations, but if you don’t, there are maybe a lot of stereotypes that…perpetuate a very narrow description of autism”
+* (R, *T* d): “educating neurotypical people on individual actions that they could take”
+* (**P** i): “for [autistic son] to make a unique contribution to help others not be misunderstood”
+* (**P** i): It feels good to be the one educating others: “I think that also from the point of view of the person giving the information, how fab will he feel”
+* (*F* d): “being in that situation [of experiencing something] and understanding exactly how it feels as opposed to what I think it feels are two very different things”
+
+### f) Creating connections/community
+
+*(R, *T* d): “I’m really excited about…people crossing over between the different groups that they may join the project in, as a member of the [developer] community and as an autistic person”
+* (R, *T* d): “building community and support within the autistic community”
+* (**P** g): “…sharing with the community…I think that would be particularly attractive”
+
+### g) Sharing expertise and personal perspective
+
+* (*F* d): “…being here is actually exceptionally useful, because I can have some first-hand experience in terms of understanding the requirements for the platform.”
+* (**P** d): My other hat is that I’m also a researcher…and the last project…was on autism and anxiety and also sensory sensitivities…so that was why I was like, woo, like it” 
+* (**P** *F* d): “I too am a mother of a child with autism…I can perhaps just bring, again, some perspective”
+* (**A** **P** d): “I’ve found a few things over the years, and then hopefully I contribute to this project a little bit my experiences”
+* (*F* g): “it’s not just around volunteering and fundraising, it’s using our key skills and expertise to do a project like this”
+* (**P** i): “the participants that I get coming in to do my research, who are nearly all autistic people…they want to actually share, but it would need to be clear”
+
+## 2. Experiences of autistic people and their families in their daily life
+
+### a) General 
+
+* (**P** i): autistic son “loves discovering new places…but sometimes it’s kind of hard, so it would be quite interesting to study that” 
+* (**P** i): autistic child finding the smell of deodorant strong/concerning
+* (**P** i): autistic son is “minimally verbal” - can’t read and can’t write.
+* (**P* d): interpersonal strain, finds daughter’s behaviour unpredictable: “it goes up and it goes down”
+* (**P** i): may have to wait for another bus if the bus is too busy because wants a specific seat
+* (**A** **P** d): as a parent and autistic person, “I’ve found a few things over the years” which have made life easier 
+* (**A** **P** d): “I know my way underground, don’t put me above ground, I think I’m a mole” 
+* (**P** i): “he [autistic son] is very empathic with people he feels are either misunderstood or coerced into doing stuff that they don’t want to do” 
+* (**P** g): “it feels awful not to be understood and not to be, you know, to be coerced into doing stuff because people don’t get that it’s actually a really big deal, so that is a real inspiration.”
+* (**P** i): “my son was absolutely losing it, completely losing it, he was just literally shaking head to toe on the train, and I was thinking – can we make it to the next stop? And this bloke came on and he had this full on three piece suit, and he was very chic, [my son] completely knew, he just chose to be very relaxed about the whole thing, he sat down, and that was completely fine”
+
+### b) Positive experiences and suggestions for improvements
+
+* (**A** d): Colour-coding on the floor of stations
+
+## 3. Platform Design
+
+### a) General
+
+* (**A** **P** g): have a popular website with lots of information
+* (**A** **P** g): “people would go and read lots of exciting information, then from there we can log in and add our own experience.”
+* (**A** **P** d): something like mumsnet: “there’s loads of people talking on forums…the prompt is you go on there to find out about motherhood, start dealing with all sorts of issues, and then you think, okay then I’ll ask this question”
+(*F* g): Critical to have a website people want to use, that, “we get this absolutely spot on for people to…want to use it and…come back time and time again.” 
+* (**P** d): “I’m not looking to go somewhere because I want to contribute…because I haven’t got much time…then eventually when I get some tips, I go, ‘actually I could contribute to that one.’”
+* (R *T*  d) “we want to make sure that it’s a safe space and it’s…[an] autistic voice first space”
+* (**P** d): “Could it be divided into different sections? Because so far we’ve got tubes, we’ve got noise, will people come up with categories or something, or just an open free for all? 
+
+### b) Demographic information
+
+* (R *T  d) some demographic information will have to be collected: “there’ll be some bare minimum information that you have to complete, which I think is just going to be, are you autistic or not”
+* (R *T* d) a lot of analyses difficult if you don’t record who is autistic and who isn’t
+* (R *T* d) (Probable) demographic information to record and request:
+* (R *T* d) connection to autism: whether the person entering the experience is autistic or is a friend, relative, carer, co-worker, of somebody who is autistic
+		* (R *T* d) “extremely important”
+* (R *T* d) age bands:
+* (R *T*d) maybe in decades, not necessarily precise age
+* (R *T* d) gender
+* (R *T d) “we’ll have some conversations with…more traditional autism researchers”
+* (R *T d) a certain amount of information will have to go in your account
+* (R *T* d) you should be able to go back and edit your account
+* (**A** d): segmentation according to demographics
+* (**A** g): “when people are looking at experiences they obviously want it to be relevant to their circumstances, so to some extent it might be a good idea if there was some segmentation in terms of demographics”
+* (R *T*  d) “I like your idea…so you’re more likely to see more relevant examples, but we also need it to actually be able to do the research on the other side, because you can quite a lot of…learning from the data by reading experiences and clustering them together”
+* (R *T* d) could allow the machine learning of similar/relevant experiences to be much faster than waiting for data to amass would permit
+
+### c) Motivation
+
+* (R *T* d) “one take home for us is we need to be really clear about where you go, why you’re doing it…simple is key, but also making it quite motivating…explaining why it’s important”
+(R *T* d) videos, for example, from someone at Transport for London, someone at the Barbican Theatre, someone we’ve already collaborated with, saying, we’re interested, like, thank you for taking part in this project, we are so excited to learn from your experiences…”
+* (**P** g): “showing…the end result, not just, yeah, yeah, we’re listening, but we listened and look what we did”
+* (R *T* d) need to gather data to make changes first
+* (R *T* d) Autistica have shared tips of sort of ways to make an environment more accessible, which could help demonstrate value of research
+* (R *T* d) Need to balance making motivations explicit with desire for simplicity many people had also expressed
+* (R *T* g) Motivating information could be upfront or on a separate page
+* (*F* g): a pop-up saying when someone lands on the page with a thank you for coming onto the website, and saying there how beneficial it will be
+
+### d) Personal Choice
+
+* (*T* R, g): “…there’s also something really kind of fun and exciting about people being able to upload lots of experiences…whenever they want to, in whatever way they want to”
+* (**A** d): “accommodate as many different preferences and styles for providing input within the realms of what’s actually achievable” 
+* (*F* d): settings page to tailor the visual aspects of the interface
+	* (*F* d): use to modify background or colour themes
+	* (*F* d): texture options, such as a wooden background, or metal
+* (**A** i): I do appreciate that other people like to customise things
+* (**A** d): “I know I’m different from a lot of people so I wouldn’t want my experience to…hold too much sway.”
+
+### e) Clear communication
+
+* (**P** d): Have a tagline: “this is what we’re looking for, this is what we want from you, and this is what we’re going to do, and don’t be afraid to repeat yourself just literally on every page like, this is what we want, this is what we need from you, this is what we expect from you”
+* (*F* d): an “about” section to clearly explain project and its purpose
+* (*F* d): a dictionary (within the “about” page) to explain terminology
+* (R *T* d) show videos of people contributing in different ways and maybe for different reasons on the about page – “I’m imagining a vignette…of three different people…who take part for different reasons, with the idea that you should totally see some aspect of yourself across those three”
+* (**P** d): “…change your language because already I’ve understood about a tenth of what you were saying - I just go – …interface – I’m lost”
+
+### f) Simplicity
+
+* (**A** d): “I’m very prone to information overload, so I would want from my point of view this default interface to be as plain and un-distracting as possible…I wouldn’t want something that was busy and distracting, it just needs to be focussed on the content.
+* (*F* g): [based on feedback from last session] limit quantity of items shown to user on page to 5 at once. 
+* (R *T* g) need to balance features with simplicity: “it’s interesting how much information needs to go on this about page”
+
+### g) Navigation
+
+First step (currently) is creating an Open Humans account:
+* (*F* g): “I’m just trying to walk through the process of how you would get to the initial page, you know, would we just type into Google and then you click on the [url]?”
+* (*F* d): “I was thinking originally I would add it to the experiences tab page, to say, in order to submit or view experiences, please log on to Open Humans”
+* (*F* d): “you could probably think of some example applications where…it says, ‘please log in’, and you’d have to log in to Facebook or Twitter the first time. 
+* (*F* g): Possible to log in via Facebook or Google as well as Open Humans? 
+* (R *T* d): “you do need to consent to Open Humans holding your data, but you can use your Facebook or Google accounts to connect to Open Humans
+* (**A** d): “This might be unique to me…I almost never take up the offer to connect users on Facebook, because I’m slightly concerned about big data, and linkages between different repositories”
+* (R *T* d): “I also don’t do that, and actually one of my goals of this project is to show that big tech organisations don’t need to have all of your data for all of these purposes.”
+* (*F* d): Use an API call to integrate
+* (R *T* d): “I think probably what we would need is to have maybe another little video that people can watch about Open Humans if they want to”
+		* (**P** d): “I think that’s too much though”
+* (R *T* d):Optional button people could click on if they were interested to find out more about Open Humans
+* (*F* d): There would only be one login for the citizen science, because we’re using the login for Open Humans as part of the login for this application
+* (*F* g): distracting to be navigated onto a different place, once you’ve gone onto a website
+* (**A** **P** d): “I go on this interesting website, I can read about autism, and then have a button in the corner – add your experience - and once I go in login from there…I would like to go for something that is useful for me.”
+* (*F* d): Instead of having the navigation across the top, have it down the side in a navigation bar
+* (*F* d): when you hover over items they indicate which area of the application they link to
+* (*F* d): should recognise new users and by default send them to the about page, which then details how to use the application and what it’s there for
+* (*F* d): Pop-up which could give tour of site, and would be easy to click off, on first arriving
+	* (*F* d): “when…a video pops up…I’ll just close it down”
+* (**P** d): “possibly what would get me there…and maybe would make me want to come back…would be rather than starting on the ‘about’ page, rather than starting on the ‘experiences’…starting on the “tips” page”
+	* (*F* d): “seeing advice from other people coming in”
+* (*F* d): button at top of ‘tips’ page saying, ‘contribute a tip’, or, ‘provide a tip’
+	* (**P** d): “then that’s where I would put my experiences, I’d put them in there”
+
+### h) Accessibility
+
+* (**A** d): Have a non-verbal means of inputting information
+* (*F* d): visual symbol on tips cards showing what it’s related to
+(* *F* d): we would need to be able to support screen readers with the application 
+
+### i) Filtering Experiences
+
+* (*F* d): filter based on categories of experience that people could select via. ‘tips’
+* (**A** g): segmentation in terms of demographics: “what’s relevant to young people, or adults, is going to be quite different”
+
+### j) Toggling Consent
+
+* (R *T* d): “I hope that it’ll look like a list of the things that you’ve put in with little switches for example where you can change your mind about who has access to what and for what purpose.” 
+
+### k) How should we ask the research question? 
+
+* (**A** g): “At the moment it’s too general”
+* (**A** **P** d): “If I just see a page which says tell me about your experiences, I would just blank”
+* (**A** **P** d): “…it’s too vague”
+* (R *T* d): “the difficulty is…it’s sort of super vague on purpose, because we don’t want to constrain anyone, and only say things about public transport, or only say things related to work.”
+* (**P** d): It’s confusing: “What am I supposed to, what am I meant to do for this, what is the idea behind your project?...as the parent I’d be like, okay, what do you want, what do you want from me, and what kind of experiences”
+	* (**P** d): It’s what is expected of us, what do you want me to do?
+* (**P** i): [speaking of an autistic person for whom they are a befriender] “…he wouldn’t understand that form, because, he’d be like, um, what do you want me to say?”
+  “maybe it’s not something about the wording itself, it’s the user journey of how you actually come to the question”
+* (**P** g): “in order to get people to join up or to contribute in the first place, hopefully you would explain there what kind of thing you would like, so by the time we get here we get some idea of what you mean by ‘experience’”
+* (**P** d): have a tagline, that this is what we want you to do
+* (**P** d): tagline shouldn’t be in the action box, as too restrictive 
+* (R *T* d): instead of having just two boxes, have quite a few smaller boxes that appear one by one with much more structured prompts
+* (*F* d): a question mark pop-up which explains what is meant at the end of the question
+* (*F* d): templates that you could submit quite quickly, but also adjust if needed
+* (P** d): divide into different sections
+* (**P** d): divide sections up by senses, e.g. visuals, auditory 
+* (**A** **P** d): divide into environmental issues, school issues, and so on
+* (**A** **P** g): should have some sort of category, but then “the form itself is good, once you’ve gone into your right category, then this is nice and simple, it would be easy to fill out”
+* (**P** g): “make clear to anybody that submitted that this would be useful for other people as well, because that would tailor the way they say things”
+* (*F* d): “potentially not necessarily sharing the actual experience itself because that could be in a negative wording, but actually just sharing the what would you wish to be…different”
+* (**A** g): “…accommodate as many different preferences and styles for providing input within the realms of what’s actually achievable…some people would prefer the free text option…but others would like to be guided down a more structured process”
+* (**P** d): “So what information would you like us to know about what you need from the platform, what is most important for you to get out of the platform, what you would like to see from the platform, and what concerns you about the medium?”
+* (*F* d): Base feedback input on “user stories” template to guide through process- start by directly asking what sort of feature you want to have in the platform, then ask why you have suggested this feature, give reasons and move onto success criteria
+* (*F* d): “alongside this you’d also have your approval to say, ‘I’m happy for this feature to be shared publicly’, and you can just submit and then it gives you your thank you for submitting the feature”
+	* (**A** **P** d): “I would find it much easier to fill it out.”
+* (**P** d): “I understand you don’t want to lead people on what type of…answer [you want people to give]”
+	* (**P** g): Makes it easier to understand the type of thing you’re looking for
+* (T *R* d): “That’s only one small slice of what we’re looking for, so that does lead into an extremely narrow set of questions, but it was clearer, but it was only because it was too narrow”
+* (**P** d): “It was narrow, but that kind of thing can be quite useful I think” 
+* (**A** g): “Question 1 could be: ‘please look at this prototype platform’, and then obviously that would be self-contained in terms of what the platform’s about, and then you could give people an opportunity to say whether this was along the right lines, whether it needed tweaking, and then you would know that you were getting what you were asking for”
+
+## l) Presenting Experiences
+
+* (R *T* g) “there’s two different points here, one is being able to browse other people’s experiences, and be able to learn from them and see them, and find ones that are similar”
+* (**A** d): Search box for experiences
+	* (R *T* d) “I think definitely a search box seems like a really good idea”
+	* (**A** d): otherwise it would be quite overwhelming, you wouldn’t know where to look
+	* (*F* d): show tags instead of a full entry text box when you search 
+* (R *T* d) “…there’s a chicken and an egg problem…in order to build links between different experiences, you have to already have quite a lot of experiences, so you have to already [have] a decent amount of data” – probably something to include towards the end of the 2-year funded window
+
+## 4. Moderation
+
+### a) General
+
+* (**A** g): “…we have got a duty of care”
+
+### b) Who should moderate?
+
+* (**A** i): Automatic moderation: “in terms of the volume of postings…you can’t manually moderate all that can you? Doesn’t there need to be some kind of automatic moderation?
+* (**P** d): “I know [moderation] is a lot of manpower…person power”
+* (R *T* d) the automatic filtering that you see on social media is extremely biased…so I think it would be really important to do it laboriously, manually, to start off with”
+* (T, R, d): Potentially use automation to scale if platform is more popular than anticipated with customised learning and automated recognition
+* (**P** d): “I don’t think you can get away from it being an individual person, especially when you’re starting off”
+* (R *T* d) distributed team of people who were helping to moderate
+	* (R *T* d) I think you would want to have a sort of a central oversight
+* (R *T* d) members of Autistica’s Insight Group or frequent contributors could be shown 5 random comments with option to accept or reject
+* (**A** d): allow people to flag/report post-moderated comments if they have concerns 
+* (R *T* g) “there’s a risk…that people who are not autistic may have their own personal opinions about what is right and what is acceptable, and those opinions I think while they might be interesting to observe, are not actually the most important opinions, and shouldn’t be the main thing in the decision-making process”
+* (R *T* d) self-moderation: “you could decide to only see comments by only autistic people, or only parents, or a combination of both”
+	* (**P** d): Have a check-list to help people self-moderate: “so before you click ‘public’, you can…check is this likely to cause offense? Is it likely to do this? Is it likely to do that?”
+* (R *T* d) “it should be a representative group of the people who are going to be writing…experiences”
+( (R *T* d) a committee: “I suspect we’ll get to the point where there is a committee where people review applications to get hold of the data”
+
+### c) Communication
+
+* (**P** i): for some autistic people the notions of private spaces are maybe not so well understood, even if they might not have learning difficulties
+
+### d) Community Response
+
+* (**P** d): debates about autistic identity: “you can easily cause offense. very, very quickly, so there’s a danger that you could just get into whirlpools of this kind of stuff”
+* (**P** d): “should anybody go off and start going down the ABA route, oh my gosh, oh my gosh, you know you would get a torrent of stuff”
+	* (R *T* i) Some will find it positive, some negative, and both responses are valid
+* (**P** i): some will credit child’s success to ABA, others will say they are suffering from PTSD because of ABA
+* (**P** i): “[a friend] spent about half an hour getting that young [autistic] man down the escalator - he was absolutely beside himself – why? Because it was part of his programme, one step in, one step out, and that’s not necessarily ABA, but then other people would say, ‘oh yes in small, incremental steps you will get your child to do and to be part of the ‘normal’ world’”
+
+### e) Concerns About Sharing Information
+
+* (**A** g): Concerns about commercial use: “[put] a ringfence around potential commercial uses, because this is intelligence which commercial interests might want to get their hands on”
+* (**A** i): “people might be wary of contributing, because they might think people just want to make money out of my vulnerabilities”
+
+### f) What should we moderate for?
+
+* (R *T* d): moderate all comments before they go live, but not moderate for research 
+* (R *T* d): personal data or things that would compromise someone’s anonymity
+* (**P** d): email addresses
+* (**P** d): home addresses
+* (T, R, d): another risk to anonymity is data triangulation, “where if you have lots of different pieces of information about someone it’s potentially possible to work out who they are, even if there’s no one piece of absolutely identifying information.”
+* (R *T* d) things like personal data shouldn’t go on there
+* (**P** d): swearwords? 
+	* (**A** **P** d): “It’s a tough one”
+	* (**A** **P** d): “I’m personally okay with it”
+* (F, i): depends on the age range of people logging on: “my 8 year-old nephew who’s autistic, he’s quite tech savvy so he’d be able to come on here and probably go onto the website, share his experiences, but I don’t think you really want an 8 year old reading swear words”
+* (**A** i): “…if you don’t include swear words, we end up quite restricting some people because that’s how they communicate”
+* (**A** d): have a setting to filter out swear words as a child-friendly option
+* (**A** **P** d): “f-ing and blind-ing all over the place… that’s completely by the by, I really couldn’t possibly care less”
+* (**P** d): discrimination and prejudice:  sexist, racist, and homophobic and other comments”
+* (**P** d): “I think bad language is a very different thing from the homophobia”
+* (*F* d): important that the content is real, if you’re “moderating it down, you aren’t getting the actual experience itself.”
+	* (**P** d): “You don’t want to make it sort of fluffy clouds, when it’s not” 
+* (*F* i): “if that experience is so overwhelming to somebody, you have to express that”
+
+### g) Redaction
+
+* (R *T* d): Option of removing pieces of compromising information, while leaving the rest of the experience intact
+* (**A** **P** i): “Very complicated, that might be very, very hard”
+* (R *T* d): “it’s very hard to do anything that is not all or nothing”
+
+### h) What would help?
+
+* (**P** d): Guidelines
+	* (**A** **P** d): “you’ve got to have a clear set of rules, from the start”
+	* (**P** d): a general rule to make clear what is and is not allowed (like Facebook has)
+* (**P** i): “even if they might not have learning difficulties, it’s still not 100% clear about what’s okay sometimes, [autistic people] may not get the level of intimacy that it’s okay to share, and what may not be appropriate”
+* (**A** g): Don’t start from scratch, look at existing models and how they might be tailored for these circumstances
+* (**A** **P** g): Who should write the guidelines?
+	* (**P** d): it needs to be a committee
+	* (R *T* d): A broad range of expertise
+		* (**P** d): someone familiar with the many aspects of autism
+* (R *T* i): it is intersectional with other kinds of experience as well
+* (**P** d): somebody who understands the sorts of problems and ways of communicating autistic people have
+* (**P** d): somebody with expertise on GDPR 
+		* (R *T* g): Would you want to help write it?
+		* (**A** **P** d): “I’m happy to”
+* (**A** d): use existing guidelines as template: “I wouldn’t want to start from scratch, obviously, I’d want to know what is the process for moderating social media, what are the rules, and how might we want to tailor that to this circumstance”
+
+### i) How should we manage access to the data?
+
+* (R *T* d): a selection committee who could decide which researchers could access the data
+* (R *T* d): specific options for individuals to choose where their data goes
+
+### j) Allowing people to comment
+
+* (R *T* d): “I think almost certainly the answer is ‘no’” [to, ‘should we allow people to publicly respond to posts?’]
+* (R *T* d): “that is social media, and social media is a whole big thing, social media already exists”
+* (**P** d): “yes, and this isn’t a new Facebook”
+* (**P** d): put links to fora for discussion in code of conduct 
+
+
+### 5. Representing others
+
+## a) Important to give everyone a voice
+
+* (**P** d): If you could not report publicly on behalf of others: “my son’s experiences would never be heard”
+
+## b) Consent
+
+* (R *T* d): “It’s extremely difficult to figure out whether it’s possible to consent to sharing somebody else’s experience…my gut feeling is that, if people want to, I think we could accept if it’s for research, but that data will not be made public for any reason”
+
+## c) Community Response
+
+* (**P** g): danger of creating controversy and public argument
+* (**P** i): “you will get parents on the one side who’ll say, my child is as successful as he or she is thanks to ABA, then on the other side you get, I am suffering deeply from PTSD – post traumatic stress disorder – because of ABA”
+* (**P** i): Making the platform less welcoming for autistic people
+* (**P** i): “be mindful that there are autistic people who will read it, and it’ll be their experience they’ll be thinking about, even though your experience is entirely valid.”
+* (R *T* i): “some of the ways that parents sometimes characterise their autistic children can be upsetting to autistic people, and therefore might make it a less welcoming place”
+* (**P** i): [examining example of potential controversial comment]: “’My tip is, this kid is trying to control you, and he needs to understand that this isn’t how the world goes, so be persistent, don’t take no for an answer, and all that kind of stuff’”, do you see what I mean, and you go… ’also understanding parent’s experiences will be valuable’, and they’ll go – ‘oh, it was hell, it was hell, he screamed and he punched and he did all these things’, I’m saying he, could be she, and you go, ‘yeah, I know, but that’s your experience of your son’s, daughter’s really bad sensory experience here’, but be mindful that there are autistic people who will read it, and it’ll be their experience they’ll be thinking about, even though your experience is entirely valid, because it is hell, when you’re trying to get somewhere, and your child has their arm wrapped around your neck and they’re pulling your hair, and often you kind of go, like, and this is a [tall] bloke, and you’re a little person, and everyone’s looking at you going oh, woah, yes, but actually his experience is probably worse than mine.” 
+
+### 6. Data Management
+
+## a) Agency
+
+* (R *T* d): “part of the point of the project is that people have agency”
+* (R *T* d): “the whole point of the Open Humans project…is to empower people to have control over their own data, and that is essentially what we’re doing here”
+
+## b) Changing consent
+
+* (R *T* d): For me…it’s very important for people to be able to change their mind
+
+## c) Which Groups or Organisations Should Learn from the Data?
+
+* (*F* d): the department of transport…”so they can adjust transport for London with regards to tailoring it and assisting people with autism”
+
+### 7. Contribution Channels 
+
+## a) General
+
+* (R *T* d): “the problem with options is there’s lots…which can be complex, so, this is what we’re currently figuring out”
+
+## b) Focus Groups
+
+* (R *T* i): “I think you can feel from the focus of these discussions that it’s really hard to be part of a project this early on, there are so many options, and there are so many unanswered questions”
+* (R *T* d): “So that’s exactly what we need in fact, that’s why these sessions are so useful, because you’re the pioneers of different solutions, and you can tell us this could be better, and then we can make it better”
+
+### c) Personal Email
+
+* (R *T* d): “that’s a private communication, and so we can’t use the comments for our research”
+
+## d) Mailbox and newsletters
+
+* (R *T* d): “So again, we were iterating the design of the letters, so the first one we sent people said was slightly too much information and too many options, so for the next one we made it simpler and specific in terms of what we were asking for.”
+* (R *T* d): “So if you reply to this it only goes to [redacted] and me, it’s not a general discussion, but you can at least stay up to date and we’ll try to send monthly updates.” 
+* (R *T* d): “…it’s very vague, kind of blue sky, but there will be a time when there’s a fully functional platform and we’ll need as many people as possible to try and use it”
+
+## e) Google Forms Survey
+
+* (R *T* d): “…if we copied and pasted it into this box, then we could use it for research”
+* (R *T* d): “I think it’s really important that something like this exists, we just need to do another pass through making it clearer about what the pathway is when you get to it”
+* (*F* d): “The reason I suggested my version of Google Forms was…if you’re confused with GitHub and how to create an issue, I thought that this was quite a good way in order to get your information as a request item and then for that to be able to be translated automatically into GitHub, so you can interface not directly with GitHub, but for that information to be put into GitHub at some stage”
+* (**A** d): “…on the first screen, it just mentions the citizen science platform, but without actually specifying that it’s about an autistic environments project, which isn’t self-contained, in explaining it enough.”  
+* (**P** d): “it’s not that bad, it’s just vague. It’s not that I’m confused by it, I just don’t know what you’re asking me.”  
+* (**P** d): “you don’t need to change it every week, you just need once to tell me what I need your feedback for is this and this is why I need it.”
+* (R *T* d): “[It’s a big] amendment to ask the University of Cambridge ethics board to allow us to change the wording [of the platform ]each week, for example, but if that’s what people are telling us, that there will never be a case where a broadly phrased question is useful, we’ll try it, or we’ll come up with a bunch of different surveys” 
+* (**A** **P** d): “…as it is, it’s fine for me, but I’ve been to these discussion groups twice, so it’s clear to me what’s going on, but what about the people who haven’t been? I don’t know if they will know what to do with it, or what you expect from them”
+* (**A** **P** d): An email along with the survey explaining what it is about would be useful. 
+* (**A** d): “I’d be happy to use that general way rather than specific correspondence.” 
+
+
+### f) GitHub
+
+* (**A** **P** d): “this is a platform that open source developers use very extensively, so what we hope is that everyone if they want to would be able to come and contribute, but it’s definitely really useful for the developers”
+* (**A** **P** d): include diagrams to make contribution pathways clearer
+
+### g) Gitter
+
+* (R *T* d):  “So this I would imagine is more likely to be used by developers, or maybe people who are both autistic and developers, and there would be a community of people here, but that doesn’t mean that it has to be anyone, but it exists, and we can support anyone to use it that wants to use it”
+
+## 8. Ways of Working
+
+### a) Diversity and inclusion
+
+(* R *T* i): “people have multiple different identities, and so having them all work together is going to be…really exciting”
+
+### b) Openness and transparency
+
+* (R *T* d): Availability/accessibility of information
+* (R *T* d): it will be a webpage, so anyone can get access to that just by going onto a webpage
+* (R *T* d): demos to get people to do the first contribution… “little animated examples”
+* (R *T* d): mailing list for people to get monthly updates 
+
+### c) Communication
+
+* (**P** d): “I think contacting schools is a brilliant way to start”
+* (**P** d): through Autistica’s Discover network
+* (**P** d): partner organisations
+* (**P** d): National Autistic Society
+* (**P** d): parent forums: “you have to have it on there, for sure, 100%”
+* (**P** d): other online groups
+* (**P** d): word of mouth
+* (**P** d): local councils (as they are mandated to provide services to people with special needs up until the age of 25)
+* (**A** d): social media
+* (**A** d): “In terms of finding adults to participate I think social media seems to be quite successful in finding me… I’m not a big user of social media, but the algorithms seem quite skilled in detecting my interests in research studies and they…pop up…on my newsfeed”
+* (**A** **P** d): NHS distributing leaflets - offer leaflets about the platform when you get your diagnosis.
+* (*F* d): Link to the Autistica conference using live streaming to promote the platform
+* (R *T* d): Wait until contribution platforms are clearer before doing a big marketing push
+

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -39,7 +39,7 @@ Based on the feedback receieved, none of the content was requested to be changed
 5. [Representing others](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#5-representing-others-2)
 6. [Data management](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#6-data-management-2)
 7. [Contribution channels](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#7-contribution-channels-2)
-8. [Ways of working]()
+8. [Ways of working](https://github.com/alan-turing-institute/AutisticaCitizenScience/blob/GeorgiaHCA-Summary1/community-recommendations/focus-group-summaries-2019.md#8-ways-of-working-2)
 
 ### Key
 

--- a/community-recommendations/focus-group-summaries-2019.md
+++ b/community-recommendations/focus-group-summaries-2019.md
@@ -1,0 +1,554 @@
+# Focus Group Summaries
+
+This file contains summaries and quotations from focus group sessions concerning the Autistica/Turing citizen science project, which was held with members of Autistica's Insight group, Fujitsu, The Turing, and Autistica on the 18th and 24th September 2019, and 4th October 2019. Quotations have been shortened or summarised, labelled according to the speaker, and all depersonalising information has been removed. 
+These summaries have been circulated to all participants to offer them the opportunity to remove or modify their comments if they wish. 
+Based on the feedback receieved, none of the content was requested to be changed, but the format was modified.  
+
+* [18th September 2019](https://github.com/alan-turing-institute/AutisticaCitizenScience/new/master/community-recommendations#citizen-science-focus-group-18092019)
+* [24th September 2019](#date-24th-september-2019)
+* [04th October 2019](#date-04th-october-2019)
+
+### Key
+
+#### Where From
+
+* A = Autistica
+* T = Turing
+* F = Fujitsu
+
+#### Specialist Role on Project
+
+* R = Researcher
+
+#### Connection to Autism
+
+* *A* = Autistic
+* *P* = Parent of someone autistic
+
+#### Connection to Experience
+
+* d = direct: experience, suggestion, or opinion of speaker
+* i = indirect: witnessed or reported on behalf of someone else by speaker
+* g = general comment
+
+## CITIZEN SCIENCE FOCUS GROUP 18/09/2019 
+
+## *Thematic Summary*
+
+## 1. Value of project and motivations to take part
+
+### Helping autistic people and their families
+
+* (F d): “I’m interested in the enabling factors of the project”
+* (**P** F d): “I have a [teenage] son with Asperger’s, and I’m really excited by all the prospects the work is going to have to make his life a lot easier”
+* (**A** d): “I’m just really interested in helping other autistic people with sensory processing differences”
+* (**A** d): “I dropped out of uni mainly because of sensory issues that I had at the time, so that’s why I’m interested in this”
+* (*F* d): “…it’s extremely exciting…to look at the application or the technology that we can provide…to such an important cohort of users”
+
+
+### Helping people more generally
+
+* (*F* d): “it’s always about the stakeholders, and I’m here to make sure that we do enough”
+
+### Gaining insight from autistic people
+
+* (*F* d): “so it’s really important for me to be here and understand everyone’s opinions here because I’m going to be the one who makes things”
+
+### Curiosity
+
+* (**A** d A): “it’s quite interesting to see what the project’s going to be about”
+
+### Allowing people to be heard
+
+* (R *T* d): “I’m interested in how we collect lots of different people’s experiences without flattening them”
+
+### To represent others
+
+* (**P** i): “I’m here representing my autistic son”
+
+### Helping educate neurotypical people and remove stigma
+
+* (**A** d): “I lived my entire life thinking I was difficult, and I was annoying…but I now know how to represent it”
+* (R *T* d): “one of the reasons I’m so excited about it is you could have neurotypical people read the experience and understand better”
+* (**A** g): “we want to persuade members of the general public that sensory sensitivities are a real thing”
+
+### Creating connections/community
+
+* (**P** g): “there’s so many things that are shared in common but if you don’t share it everybody thinks, ‘I’m the only one’”
+
+### Sharing expertise and personal perspective 
+
+* (**A** d): “I’m here because I’m autistic and also very opinionated…this is kind of my thing”
+* (**A** d): “I’m autistic so I’ve got an awful lot of experience which I hope to contribute to the group”
+
+### Supporting and improving research
+
+* (••A•• g): “recently [in] one of the journals someone did a meta-analysis called ‘sensory experiences’, and it’s so prevalent it should be included in the core characteristics of autism, which it isn’t currently”
+* (••A•• d): “I’m very interested in what are the ways the data is captured – how it could be interpreted with fidelity, so we don’t lose the meaning”
+* (R *T* d): “I’m really interested now in how we can do open and ethical and transparent research which is slightly more impactful on a shorter-term basis than neuroimaging”
+
+### Long term benefits
+
+* (**A** d): “I think the IT programme project is always the most exciting, because it can leave a lasting legacy”
+
+### Learning
+
+* (*F* d): “I’ve learned more about autism in the last 6 months than I knew ever before”
+
+## 2. Experiences of autistic people and their families face in their daily life
+
+### General
+
+* (**A** **P** d): “I’m still recovering from a bit of shock because the council is refurbishing the town hall... I had to travel out of the building in a lift which isn’t finished, so to my mind if someone lit a cigarette the lift would blow up”
+
+* (**P** i): “my son’s hearing is extremely sensitive, so he needs help” – son can hear conversations others would not be able to, and is troubled by sounds such as flushing water. 
+
+### Misunderstanding and Stigma
+
+* (**A** P d): “…by the time I got to the ground floor I was shaking, and had to try to sign out, and explain to the guy why I was upset, and he didn’t seem to think it was of any importance whatsoever”
+
+### Communication
+
+* (**P** i): “…although my son’s autistic, and he is very high-functioning there is a point where…he is very non-verbal, so I have to meet him halfway in sharing something”
+
+### Travel
+
+* (**A** d): sound of buskers while walking in Central London – “they’ve all got bloody amplifiers now haven’t they and it’s horrific, absolutely horrific”
+* (**A** **P** d): “why does TFL think I want to listen to loud classic music in a bus station, you know, Ride of the Valkyries or whatever, it’s making me feel quite nauseous…” 
+
+## 3. Platform Design
+
+### General
+
+* (R *T* d): “everything about this can change, everything about this probably will change, based on what you tell us today”
+* (**A** d): have an organised, online discussions forum 
+* (R *T*  d): “…maybe you could upload a photo, maybe geotag where you put that photo”
+* (R *T* i): “if you’re currently experiencing sensory overwhelm, an overwhelming sensory environment, that is probably not your most chilled out moment to go ahead and fill out all that information…we…probably will need to add in an option to go back and do it later”
+* (**A** d): “…most importantly I think from a motivation point of view, it’s got to be fun”
+* (**A** d): “it’s got to be educational” 
+* (**A** **P** d): “you could give options for options, so you could say, for example, ‘would you like a template?’”
+* (**A** d): there are two important aspects: what can autistic people do to change their environments, and what can autistic people do to protect themselves from their environments. 
+* (**A** g): “if you’re autistic you want to know…[how] are other autistic people with their expertise…dealing with it? Have they got something to solve the problem?”
+* (**A** d): “I would really love to have sanctuaries marked on”
+* (**A** g): “we want to make it as accessible to as wide a scope of the autistic community as we can”
+* (*F* d): if there were multiple pages you’re guided through, have the option to pull out, but still submit information already provided 
+* (R, *T* i): “saving for later and…coming back to a draft is really, really valuable”
+* (R *T* d): “one of the reasons that I as a neurotypical person…quite like the one box, is that you can write as much or as little as you want…”
+* (R *T* i): “the flipside is it’s super overwhelming and there’s too many things that you could write, so I understand the need to have some structure, but I don’t want the structure to be a limiting factor on people actually clicking submit”
+* (R *T* i): “really important to road test and user test with autistic users”
+* (*F* d): prioritise a single text box, test it, and add granularity later  
+* (R, *T* i): start with three boxes and then extend it, “we’ve heard it so loudly from other conversations that a single box is just not a viable way of inputting your experiences”
+* (R *T* d): “if somebody just says, ‘tube was busy’…that’s still really valuable, you don’t need tonnes and tonnes of information”
+* (R *T* d):  drafts could be saved but would stay private, and would only be accessed by the person writing them
+* (**P** **A** d): have ‘flags’, so specific institutions (such as, e.g. TFL) could be made aware of problems 
+	* (*F* i): “I think…the analytics that will be happening post input”
+* (*F*, d): a simple answer is possibly to put in a hashtag feature, and “in the analytics you can then do a pickup on a hashtag and then on a topic.”
+* (**P** **A** d): highlight that as an option, “because I’m still very used to the hashtag” 
+* (**P** **A** d): Important to deliver on promises: prior experience of being incentivised to use an app (Molehill Mountain) because it promised to give a mood graph, and was frustrated when this wasn’t offered
+* (**A** d): automatically link up to physiological data, for example from a Fitbit, so it could be recorded in real time. 
+* (*F* d): “I think it’s probably quite far down the track in terms of development, but I think it’s definitely worth having on there that we could potentially look at including physiological data”
+* (**A** d): have graphs linking data
+* (*F* d): there are potential API options
+* (R *T* d): Open Humans [backend provider] allow ways to link up with multiple other personal data sources – including your Fitbit, your genome, your google search, your Twitter account – once you’ve entered your experiences onto the platform, you, “could upload your own data and you can see how those things match up together, so that I think is extremely easily supported, outside of the scope of our project”
+* (**A** d):  “I think it would be useful to create age brackets, because it would be extra data for the research…it could be that certain sensory processing difficulties present to the greatest severity in a particular age group – I think that would be very useful to capture”
+* (**P** *F* d): would be useful to capture age when you are diagnosed 
+* (**P** *F* d): platform could be a route for people to come to find out about autism and then get a diagnosis
+* (**A** **P** d): translation function: “we’re all being quite naïve that the input will be in English”
+* (*F* d): Input would be free text, so could take any language, but language of navigation of site interesting to consider 	
+* (*F* d): “potentially we can look at that as a longer-term development, so initially say that the interface is in English but feel free to input in whatever language you wish”
+* (**A** **P** i): ”a lot of the autism advocacy community…is European and Somalian, and they continue to complain about health interfaces that they really struggle with trying to relay their information even though they’re given the opportunity because when they really struggle with something it’s emotional, but they immediately revert back to their native language and they’ve got no way of filling it in” 
+* (R *T* g): “one of the great benefits of citizen science is that it can be a totally global participation…even though it is more likely that people who engage will be English speakers at the beginning”
+* (R *T* d): put together an explanation and documentation of why English has been prioritised 
+* (R, *T* d): “bake into the design that it can be translated, you can collect things in different languages”
+
+### Use it to see your own data and input (**A** d)
+
+* (**A** d): make it something that an autistic person could use with their mentor – help create plans
+* (**A** **P** d): “definitely” want to see own data and input
+* (**A** **P** d): would help to trace causes and correlations based on patterns of occurrences 
+* (**A** **P** d): “…with the accumulation of data…you begin to see connections in your own life – and that adds value, you know you were talking about increments of value, but increments of value going both ways”
+* (**R**, T d): because it might be hard to fill in a form in the moment, “…it won’t be the case that you can assess what times of the day people are feeling most stressed based on the data that they input”
+
+### Navigation
+
+* (**A** **P**): make the address, “something really specific, like Autistica/AlanTuringExperienceLog”
+* (**A** **P**): make the address, “shorter and kind of clear, [so] the minute you go in and add [your] experience, it’s consistent”
+* (**A** **P** i): ways of entering text and navigation are different on different devices, so for older people it might help to have the journey guided by arrows, for example
+* (*F* d): a joystick on the page, that…navigates you, demonstrates how something should be filled in 
+* (**A** d): sequential navigation, “it’s got to be… logical…if you do this option, take you to the next option”
+
+### How should we ask the research question? 
+
+* (**A** d): “…the question, share your experience, is incredibly general”
+* (**A** d): split the question up: “Where were you? What time was it? What happened? What effect did it have? and What would you like instead?”
+	* (*F* d): you could break those down if you wanted prompts
+* (*F* d): limit it to 3 inputs where you could put in a couple of those at the same time
+* (*F* d): capture recommendations and learning
+* (**A** d): “…it’s crucial to have a field that can capture…learning and solutions”
+* (**A** d): Make the question about solutions as well as experiences
+* (**A** d): “I want to be able to say and this is what I think would have helped – you know, it may be that it’s not possible to do the thing, you know we can’t probably make the tube quieter very easily, but we do have ideas about what might help and we should be including those” 
+* (**A** **P** d): include templates: “it would be cool to have an actual template, or, at least you could have the option, right? If you want to try and have this as clear as possible, definitely clicking through similar ones”
+* (R *T* d): “I think…there’s a chicken and the egg problem because you’ve got to have a bunch of people to find similar ones”
+* (**A** d): give people a response when they’ve submitted
+* (**A** d) “…after you’ve clicked on ‘share’ there’s no tangible message that it is shared.”
+* (**A** **P** d): specifically ask for physiological or emotional information, for instance, does it prompt heart rate, swearing, shouting, emotional response?
+* (*F* g): record positive as well as negative experiences: “there is a lot of psychology that shows us that the more we focus on negatives, the more we find it”
+* (R, *T* d): “there’s this expectation that when people talk about autism they’re going to be looking for negative things, and actually there’s loads of benefits to sensory processing differences”
+
+### Motivation
+
+* (**A** d): make motivation salient
+* (**A** d): “what motivation is there to actually put things on there?”
+* (**A** **P** d): activity log for Google Guides helps to track input: “it’s my incentive to keep doing them because they let me know I’ve done this, this, and this, you’re in the top 1%, it does keep me going”
+* (**A** **P** d): “that’s my incentive…I’m being told that my contribution is valuable”
+
+### Make scope of research clear
+
+* (**A** d): “I think you need to have some kind of link to explain what research this could be used for and the limits of what it could be used for”
+* (**A** g): “…there is an enormous lack of trust among autistic people when it comes to research”
+* (**A** g): “I think that needs to be very, very transparent, because there is that lack of trust”
+
+### Reading others’ experiences
+
+* ( R *T* g): Would you be interested in reading other people’s experiences?
+* (**A** d): may cause additional stress: “don’t particularly want to be aroused, as it were, by reading about things”
+* (**A** d): “have a facility where I can go and see other people’s experiences, because that might be most useful to me”
+* (R *T* g): viewable-by-others option means people get something more immediately valuable for themselves 
+* (**A** d): People can share solutions with each other: “I can’t tell you how many people don’t know that these exist – these are industrial ear defender headphones with Bluetooth, they are what you use if you want to…listen to music while operating an automatic drill”
+
+### User Interface
+
+* (*F* i): “what are the things with autism to think about lining it up with a visual interface, that is not itself going to be a sensory issue?”
+* (R *T* d): “there’s a balance between being really boring…and being too stimulating, actually” 
+* (**A** d): an accessible colour scheme
+* (**A** d): “I think it should be more visual than…written”
+* (**A** d): “the words used, or any writing used” should be “well-spaced out and in a good font that anyone could read - and obviously a screen reader could pick out as well”
+* (**A** d): “make the platform accessible for…non-verbal [people]”
+* (**A** d): “maybe when you’re designing it you can have different colour schemes, or choose your own one, so that it’s not overwhelming”
+* (**A** d): the text boxes could be framed like a mirror, with a wooden background so the text boxes are a mirror on which you write your reflections, “so it’s a very peaceful thing, it’s a very natural kind of place, where you could just relax and write”
+* (**A** d): it’s got to be inviting, it’s got to be visually attractive 
+* (**A** d): it’s got to be easy to use, 
+* (**A** g): upload pictures of situations that were a problem, so that organisations can go onto the platform and easily see what to change, “because visual things can have much more impact than just…a dense script” 
+* (R *T* g): would probably be able to take visual inputs – analysis of them out of scope for user interface; would liaise with colleagues who do computer vision 
+* (**A** **P** d): “you don’t want too many things on the page at the same time, because it’s just too much”
+* (**A** **P** d): have a satisfying noise when you submit information
+* (*F* i): have the same information available to you whether you’re on your laptop or your phone
+* (**A** **P** d): “that actually matters to me because I… switch between android and iPad, and It’s how I choose to live my life, but it can be annoying when things don’t work out”
+* (**A** **P** d): “I get very frustrated by a countdown of the amount of characters I’m using”
+* (**A** **P** d): “please don’t put a word limit, and especially not seeing it count down, because it’s very horrible”
+* (*F* i): include notifications, which ask how you are feeling, to prompt those who might not be as expressive (for example, ‘how happy are you feeling?’) 
+* (*F* i): “…we might be picking up people who are in distress but they’re not reporting it because they don’t want to fill out a whole field”
+* (**A** **P** d): found filling in diary prompts every day “irritating” 
+* (**A** d): “The kind of pop-up, how are you feeling right now…should probably be something that people opt into” 
+* (**A** d): “…green would be a good colour – more inviting” 
+* (**A** **P** d): “Yeah, there are some great shades amongst the greens aren’t there, there’s a nice sort of fresh spring, and then there’s that, what do you call it, a middle, sort of forest green –”
+* (*F* d): “Tahuna font is a bit softer than Ariel, so maybe give that a try”
+* (**A** **P** d): icons ned to be slightly bigger
+* (*F* d): have a glossary or dictionary of terms
+
+### Accessibility
+
+* (**A** d): Take into account learning disabilities as an accessibility feature: 
+* (**A** i): “it must be very difficult for people who are not as intellectually capable, and quite often they probably just give up in frustration”
+* (**A** i): have a simple graphic at the side explaining site navigation and what steps to take
+* (**A** d): make a button you can press for help to come up
+* (**A** d): pop-up window that explains to you what the text box is, or gives you a visual guide saying exactly what buttons to press
+* (**A** d): less information on one page: “I’ve always been better if there’s less information on one page”
+* (**A** d): bring one thing up at a time
+* (**A** d): have an arrow bar to move onto the next piece of information, rather than having to constantly scroll 
+* (**A** d): “just one thing or question or visual per page, and then…press next”
+* (**A** **P** d): that would make it better paced
+* (**A** **P** d): have a maximum of 5 things on a page at a time 
+* (*F* i): research could be quite self-selecting, “…in a lot of areas the quietest people are the ones who need the most help”
+
+### Longevity
+
+* (*F* d): “what we should be thinking about as well is…the next generation [of contributors]…they should be able to contribute just as easily, and so if we can think of any ways to make that easier, then we can start putting those into the process now”
+
+### Benefits to user of platform 
+
+* (**A** d): adapt features such as those of Brain-in-Hand to give people self-knowledge: “it…helped me to work out what my triggers were, and what days were hard for me to be at uni or anywhere”
+
+## 4. Moderation
+
+### How should we moderate?
+
+* (**A** d): provide some kind of feedback that moderators have experience, because otherwise it just “disappears”
+* (R *T* d): “you do need to know that a) the research is going ahead, and b) you know that it might not appear for 2 or 3 days or whatever that time scale is”
+* (R *T* d): comes down to, “how do you make everybody feel safe in a community?”
+* (R *T* d): “…we probably won’t moderate for [experiences] only used in research”
+* (R *T* d): “there needs to be an option of safeguarding people and making sure that it remains a welcoming environment, and space for people to browse and put their experiences on, so we have a really big unknown at the moment which is how that process will work”
+* (*F* ** P** d): one option would be to moderate all comments from new users, and if they dependably don’t contravene code of conduct, put them into a ‘do not need to moderate’ category
+* (R *T* d): “things can slip through the net, so it is a balance I think between feasibility and an ideal system”
+* (R *T* d): “there is a natural language processing option for some types of moderation, but it is not a perfect option, not an ideal safeguard, and there are problems with potential biases” 
+* (*F* d): people could flag comments for moderation, and then be prompted to say which part of the code of conduct it violated. 
+* (*F* d): if comments flagged multiple times they could be prioritised for moderation 
+* (*F* d): moderators could cross-reference their decisions against general public
+* (R *T*  d): “that also means in practise that the whole community of people are moderators, and it’s not just a limited group, anybody could flag a comment, and everyone is involved…it’s more democratic”
+* (*F* d): flagging comments would also help to bring up issues that might not have been previously thought of
+* (R *T* d): “you can remove data from the public immediately…that doesn’t mean other people haven’t seen it, or…copied it, and I think we have to be realistic about what you can retract.” 
+* (**A** d): “from a user point of view, people have got to feel safe and comfortable while using the platform…if you get spam or stuff on there, or comments that have not been moderated out, and you don’t feel comfortable with it, then they won’t use it!”
+* (**A** d): “I think you have to work on the basis, unfortunately, that every single corner of the internet which doesn’t have moderation just seems to fill up with Nazis, they’re everywhere, and it happens in the most unlikely places, so I would say at least for the first couple of times you need to moderate the users”
+* (*F* d): “there’s the…malicious side which you need to be wary of…but also I think you need to be helpful to people as well”
+* (*F* d): if someone puts in personally identifiable information, “we should be able to pull that out for them… this is a more positive aspect and a helpful side.”
+* (**A** d): “you can’t just say, ‘this has been moderated out’, you’ve got to provide an explanation”
+* (R *T* d): should we redact parts of comments, or refuse comments entirely? 
+* (R *T* d):  “if someone had written it to include information that it was dangerous to put online, but the rest of it was fine, could we send a suggested edit”
+* (R *T* i): “it may be offensive to somebody to have their own experience edited back to them”
+* (**A** d): have a panel of autistic people to look over trends in comments
+
+### Self-moderation
+
+* (**A** d): include option to moderate out distressing or negative experiences: “if I’m feeling particularly stressed and I’m going to go on a platform, I don’t want to be reading…a lot of what went wrong on your day, I’d rather click on a button that filters to the – what happened, and what went well, and who accommodated you well”
+	* (**A** d): different types of experience could be colour-coded 
+* (*F* d): you could blacklist people whose comments you didn’t want to see, or only see your own comments
+
+### Who should moderate?
+
+* (**A** d): Should reflect people who contribute “I think that it should be a mixture of people, people who are autistic and maybe parents of autistic people, because then it’s a wider scope…if there are gonna be parents, guardians, etcetera…who are contributing, advocating for the autistic person that they care for, that are in their lives…then there needs to be people who are also in that category to moderate, not just coming from an autistic person and vice versa”
+* (**A** d): important to have more than one person look at each comment
+* (**A** d): “they need to be objective, something that might be okay for one person might not be okay for someone else.”
+* (**A** d): option to have multiple people look at a comment without necessarily communicating with each other (but you could see their decisions) - all of the different moderators put their response and then somebody else will collate all those responses (presumably majority sway)
+* (**A** d): “I think you’re gonna need a team of moderators especially if this becomes successful otherwise it’s going to get way too much for one person.”
+* (**A** d): “if you’ve got somebody who’s submitting regularly, who never goes outside the guidelines, you could perhaps invite them to be a moderator”
+* (R *T* d): This could be a branching option, where moderators could select other moderators, and is therefore quite scalable
+* (R *T* g): try to make sure that panel is representative of, not just autistic people but different cross-sections, because they will have more diverse lived experience
+
+### What should we moderate for?
+
+* (R *T* d): “information about someone else that could be either offensive or compromising in some way”
+* (R *T* d): information about someone else that might be distorted
+* (R *T* d): comments demonstrating animosity to autistic people
+* (R *T* d): “we also want people to be able to express a wide range of opinions, and not to shut that down”
+* (R *T* d): “certainly how I was imagining it was that we wouldn’t moderate for research”
+* R *T* d): “there’s nothing that’s not useful for research if it’s handled well by analysts”, for example, exposing existing prejudices 
+* R *T* d): what’s public should be, “of benefit to autistic people and their families”, and “representative of autistic people”
+* (**A** d): “…If you have your clear criteria, then it either does or it does not fall within those criteria” – would make the task of moderation easier. 
+* (**A** d): “I think you need to have a system in place for what you are going to do to deal with it if you get people posting not in good faith…in some of the dark…nastier corners of the internet they have a real thing about autism…using it as a slur against people, and taking the piss basically”
+* (**A** d): this could also be a problem not just for posting on the platform, but if comments get reposted: “if this shows up and somebody posts it to 4chan, you are going to get thousands of malicious posts”
+* (**A** d): spammers and scammers: “the National Autistic Society site is always getting done by spammers, people who are trying to sell you false passports or all this sort of stuff.” 
+* (*F* i): personally identifiable information: “someone might…have had such an anxious experience…that they might accidentally put in their name…or their home address”
+* (**A** d): “people deliberately trying to bias the data by putting in accounts…which pertain to sensory processing but aren’t actually authentic?”
+* (**A** d): if certain themes come up a lot or, “if there is a group of people who are pushing a particular agenda, or a view, or an experience”, authentic autistic people could moderate and say, ‘no, that’s not really us’”
+* (R *T* g): offensive language?: “in a sense there’s something very rational about the expression of anger and frustration, and also very valuable… on the other hand, that could be offensive to some people, depending on how it’s expressed”
+	(**A** d): “I have no problem with swearing, I love swearing, I’m a very sweary person”
+* (**A** d): potentially have an option in your profile to hide comments with offensive language. 
+* (**P** *F* d): automatically convert swear words into other words 
+* (**P** *F* d): would need to have an explanation in the code of conduct to say these sorts of words will not be published
+* (**P** *F* d): consider which age you would moderate profanities for: “my [teenager] would want to be sharing his experiences, because he’s very forthright about sharing experiences… I don’t particularly wish for him to see a whole bunch of profanities”
+* (**A** d): things that are offensive such as racism and sexism.
+
+### Tags
+
+* (*F* d): “you can take the tags that relate to the experience, and then you don’t actually see the free text of the experience, unless you want to investigate it for yourself”
+* (**A** d): It could be a good thing to have suggested tags
+* (**A** d): “you would have a whole bunch of people reusing the same tags”
+
+### What would help?
+
+* (**A** d): clear instructions, “I think you need to have a very, very clear set of rules”
+	* (**A** d): rules should use autism-friendly language
+* (**A** d): ask the moderators to accept or reject according to whether or not it breaks the rule, rather than subjective judgement
+* (R *T* d): “would you imagine the moderator would have to say specifically ‘this is the thing in the code of conduct the comment contravenes’, or is it more general?”
+* (**A** d): clearly aligning decisions with rules “…would be helpful, as somebody who…because I wasn’t diagnosed until I was 27…spent an awful lot of time being told, ‘how dare you, you were just rude to make that remark’, and I’d go, ‘what did I do?’, and they’d go, ‘you know what you did’…it’s quite useful to be told what you did”
+* (**A** d): “I agree…clear guidelines of what should and shouldn’t be moderated”
+* (**A** d): “give people a (limited) ability to argue back”
+* (*T* R, d): “…one of the benefits of having the moderation system in place is you could have that conversation privately, so it’s not going to be a problem for other participants, it’s between the person who submits and the moderators”
+* (**A** **P** d): give people specifics of what they could change for their comment to be included, for example if they are using swear words
+* (**A** d): have clear feedback which is “sensitive, non-judgemental, and constructive, saying how they would alter things”
+* (**A** d): have rules in the code of conduct about crusading
+* (**A** d): ask people from Autistica what they think should be in a code of conduct 
+* (**A** d): use other codes of conduct as templates and adapt them 
+* (R *T* i): “…involve lots of autistic people, and autistic people’s families, in building it” 
+* (**A** d): useful to have a generic code of conduct, email that out, and get feedback on it
+* (**A** d): “my first thought is, this is such a vague question and I can’t think about what I’ve got to say…but if I saw one, I’d be able to say, okay that’s not very clear maybe, or this needs to be adapted, or this needs be added, but it’s very difficult to just start from a blank state”
+* (R *T* d): having some kind of prototype version, but then getting lots of different eyes on that version
+
+### Allowing people to comment
+
+* (**A** d): May create arguments: “…if people could message, like, say about, or comment on the experiences, there’s pros and cons to that because if it’s going to be like a thread style, sometimes there could be arguments”
+* (**A** d): “I’ve been…guilty of it by accidentally saying something that’s offensive, or sounds rude”
+* (R *T* d): replicates existing platforms: “my reasoning, although I would be happy to discuss it further, is that I think there’s lots of places online to have those sorts of discussions about things, and I don’t feel like building another Twitter”
+* (**A** d): personal experience should not up for debate from others, “because it’s my experience, there’s nothing to debate about it - what does some other random know about it?” 
+* (**A** g): “I think that will encourage good will, because it will encourage people to feedback more” 
+
+## 5. Representing others
+
+### General
+
+* (**P** *F* i): “…my son very much is his own person, and he would want to go over what you’ve done anyway…so you’d never be able to get away with a wrong submission”
+* (**A** **P** i): “there’s no way [my son] is having the same experience I am, but he is experiencing some things which he can share with me”
+* (R *T* d): “I feel like it’s important that we do allow it”
+* (*F* d): Tag experiences, and instead of publishing full experiences in list, publish the tags
+* (*F* d): “…you take the free-text field about how the experience could be improved, and put that against the tag…because it’s very much more positive”
+* (**P** d): “we’re not going to actually get away from parents who through frustration have what they perceive as a negative experience”
+* (**P** d): direct parents to places that might be useful, if they want to talk about their own experiences, instead of having them use this platform
+* (R *T* d): for things which aren’t appropriate to the platform, include sets of resources that could help with people’s issues
+* (*F* i): “I think that what you say is great, because people do need to understand what platform to go onto to try and get support from other parents, but maybe this is not the right platform”
+* (**A** **P** d): “Yep, yep, so setting some scope, I mean we do need some scope!” 
+* (**P** *F* d): “oftentimes the reaction of the parent or the caregiver can exacerbate the situation – that’s actually a piece of data you might want to research and understand”
+* ((R *T* d): The ways parents and carers narrativize and understand autistic people’s experiences would also be useful for research.  
+* (**P** *F* d): “…it takes an awfully long time to figure out whether it’s a hug that helps or standing back or not – so those are again sensory things that happen that contribute to the data”
+* (**A** **P** d): “one of the best phrases is, ‘just say what you need’, it’s so simple” 
+* (R *T* d): “it would be really useful to capture…not just what are the experiences but how do people respond to the experiences, what effect did that have?”
+* (**A** **P** d): “being able to reflect on experiences, decide what to do next, and choose solutions would be useful.” 
+
+### Important to give everyone a voice
+
+* (R *T* i): “I wonder if for parents, there is something about the parental experience as well that needs to be captured?”
+* (**A** d): “maybe have a separate section for parents, but I do think you probably want to keep them separate”
+* (**A** i): “one of the problems is that parents do feel that they’re not being heard…there needs to be a way of hearing what parents have to say, and to give parents support, without turning it into, ‘God, this is awful’, so the big ‘but’, this doesn’t necessarily have to be the place to do that”
+* (**A** i): could be useful for some parents, especially if it’s a post about what could be done to improve an environment
+
+### Autistic voices being drowned out or elided
+
+* (**A** d): “There are a lot of places where autistic people are sharing their experiences, and they get overwhelmed by other people who have an autistic relative or something, and they have someone else talking over them…it can get really hostile, because I think there are a lot of people who haven’t really absorbed the fact that we have an experience as people, and they’re still thinking of us as difficult children who have to be managed, as opposed to people who have their own experience, and that’s my concern…that we’re going to end up with the same toxic environment if we do that.”
+	* (R *T* d): “I think that has to come through the moderation”
+* (**A** d): “…sometimes…they’re complaining from a neurotypical point of view about how difficult the child is, or the adult is, and I kinda don’t want that…because I feel this is supposed to be a safe platform for autistic people to talk about their experiences”
+
+### Guidance for representing others
+
+* (**A** **P** g): make sure, “it’s gone through people who might have insight as a parent or a carer, and it’s submitted with the approval of the cared-for person” – this could be a prompt
+(R *T* d): “there’s still a problem with that though, the carer saying yes, even though they haven’t actually got that from people”
+* (**A** **P** d): “I’d hope that they’d be honest, because we suffer very much from being lost in translation… I would censor myself”  
+* (**A** d): “I would be absolutely fine with, ‘we went into a supermarket, Jack became upset because the lights were flickering again, this is something that has bothered him before’, whereas I would have a real problem with the parents saying something like, ‘We went into the supermarket, Jack had a bloody meltdown again, I hate it when he does this, it’s so difficult being me’, because we do see an awful lot of parents complaining how difficult we are to deal with – people like us – so I think there needs to be something in there about this group has to focus on the person’s experience not the caregiver’s experience.”
+* (R *T* d): “it should be about the autistic person’s experience and giving it as much fidelity as you can”
+(**A** d): “when you ask about a sensory experience it’s about a sensory experience, it’s the autistic person’s sensory experience, not the parent’s. They might be having a psychological experience, it’s not about sensory processing differences”
+* (**A** d): “it’s very difficult to make a place welcoming to autistic people when you also have a lot of neurotypical people explaining about autistic people”
+	* (R *T* g): “that could be a key feature of the platform’s code of conduct”
+* (**A** d): “I think that needs to be a feature in there somewhere, think about how you word it”  
+
+### Suggestions for processes
+
+* (**P** d): “I think it might be useful to have a sort of intermediary space where you can share that with your caregiver or your parent…so they can see your experiences, and just look at your experiences, but nobody else’s”
+* (**P** d): “that’s helping make it more understandable, it’s about how they can adjust their own environments, from a caregiving perspective, so to help that individual”
+* (R *T* d): have a collaborative submission, “so one person would write it but another person with their own account would verify it?”
+* (R *T* d): potentially “an added level of complexity”
+* (**A** d): have a separate space with carers or friends where comments could be moderated 
+* (*F* d): a template could be set up by the caregiver, and then that could be instantiated by the person being cared for during each experience
+* (R *T* d): “the platform could collect information from parents, but it may not make visible the experiences of parents, we could mostly aim for that?”
+* (R *T* d): “we want this space to be…most in the voice of autistic people, but it would be quite interesting from a research point of view to also be able to capture the experiences of parents, for research purposes, for example to compare and contrast whether people see things in the same way or not.”
+* (R *T* i): “if you were to enter experiences on someone’s behalf, that seems like it needs a special kind of attention to moderate”
+* (*F* d): model on GitHub pull requests: a parent or carer could upload an experience, but then the autistic person would receive a notification, and they could then agree or disagree to it being submitted
+* (R *T* d): “that’s also the kind of process whereby we could potentially collect some metadata to see how often different kinds of experience were accepted”
+* (R *T* d): the disadvantage could be that it makes the structure and interface more complex
+* (**P** *F* d): important to consider age as well, may be more acceptable for parents to comment on behalf of younger children
+* (*F* d): key difference between a caregiver assisting a person to give an experience, and the parent giving their own perspective on what they are seeing 
+* (**A** **P** d): If you segment the population into autistic people and parents, you need to account for people who are both, who may be filling in an experience for multiple people at once:  “I don’t think they should fill it in twice, as the parent and as an autistic adult, to make that decision”
+* (*F* d): have a checkbox at point of the submission of the experience if you are submitting on behalf of someone else
+* (R *T* g): “one possibility for the public comments is that we could exclude ones that are submitted on the behalf of someone else completely”
+* (R *T* g): “the disadvantage of that would be that it would be a whole demographic, so a whole set of people on the autism spectrum who then couldn’t connect to each other”
+* (R *T* i): “parents might really want to connect to other parents”
+* (F, d): flag comments made on behalf of someone else for a greater level of moderation
+
+## 6. Data Management
+
+* (R *T* d): separate tick-boxes for sharing with research or publicly: “…what’s important here is that you can choose either, or both, so it depends on…the individual person who’s filling in this form – it depends what their motivation for sharing their experience is”
+* (R *T* d): “you can delete [your experiences] if you decide in the future you actually don’t 
+want that to be there anymore”
+* (**A** d): What happens if you don’t click either option?
+* (R *T* d): you would be shown a series of your own experiences, and some researchers could see them, but they would not be made public or used for research
+* (**A** g): “…if you use it for research will you get contacted in any way?” 
+* (R *T* d): “that is an open question – so can you tell us would you like to be contacted, or not be contacted?”
+* (**A** d): “I guess it depends on the kind of information that I’m sharing – if it’s not something that I really want to revisit again, then maybe not”
+* (R *T* d): consent for future purposes (don’t need to be re-contacted but can withdraw) an option
+* (R *T* d): the way that we want to design the platform is that you can remove the consent. at any time, and that’s an important point
+* (R *T* d): more fine-grained consent checkbox, with more frequent recontact, also possible
+
+## 7. Contribution Channels
+
+### General
+
+* (R *T* g): “there will be a range of levels depending on your technical ability and what challenges you are able to go through to access it”
+* (R *T* g): “I think the ideal is that we would have lots of options, so people with different preferences would choose the ones they like best”
+* (**A** **P** d): found colour-coded visual diagram of different options useful 
+* (R *T* i): “I think if someone turns out to be very challenging but it’s not obvious from the outset that it’s going to be challenging, that’s much more irritating than if it’s clear from the start that you probably need some sort of technical background”
+
+### Focus Groups
+
+* (R *T* d): “a treasure trove of ideas”
+* (R *T* d): ‘…one of the things that comes out of the discussions is how much people’s thoughts and ideas and priorities exceed the scope to discuss them in person’
+
+### Google Form
+
+* (R *T* d): from a research perspective this is the preferred option, because we have ethics approval, so anything that gets put in here can be used for research
+* (R *T* i): “this is a way to reach the people who may not be able to join the discussions in person as well…who may struggle to reach the venue”
+* (R *T* d): a way to reach people who have additional thoughts
+* (R *T* g): you could always fill this in as many times as you want to
+* (R *T* g): everything that is entered is public, but participants will be anonymous
+* (R *T* g): all comments will be moderated by the research team before they are published
+* (R *T* g): “the reasons [the question] is so general is that we didn’t want to impose anything on anyone, we just wanted the ideas to come from you”
+* (**A** d): “’needs, priorities, desires and concerns is far too long’…is there a word that you could use that covers all of them like ‘expectations’ or something?”
+* (*F* **P** d): it could be broken up to make it more precise
+* (**A** d): “I think you do need to split it up into: ‘what works?’, or, ‘what do you want the website to be like?’, or, ‘what different sort of posts and experiences would you like?’”
+* (**A** d): “What do you want to get from it? What are the most important things for you? Do you have any more concerns?”
+* (**A** *A* d): splitting the box up might be problematic if you just had a random thought come into your head 
+* (**A** d): you could always have a ‘miscellaneous’ box for those sorts of comments
+* (R *T* i): splitting it up might make people feel they have to answer a series of questions, but they might only have one thing that they want to express
+* (*F* d): “You could just use the same approach of taking the form and generating a user story, so, ‘as an x, I would like this because, for this reason’”
+* (*F* d): If you design the form to ask questions like user stories, it would be fairly simple to translate it over to GitHub.
+* (**A** d): “’what information would you like me to know about blah blah blah’ is a very long way of saying, ‘what do you want us to know?’”
+* (**A** d): “’tell us what you want’…it’s very indirect, it’s quite irritating”
+* (**A** d): “If you [ask] tell us what you want us to know, it’s an even broader question, it could mean absolutely anything…we need to ask questions that are actually relevant to the project.”
+* (**A** d): “you could put it very simply – ‘what do you want this project to do?’ And then you could split it down into the areas that you might want to contribute to”
+* (**P** *F* d): “from a usability perspective oftentimes we’ll ask a yes/no question …you don’t see the box if you don’t have a concern, but if you do you can put it there”
+* (**A** **P** d): if presented with a word limit, “I immediately disengage… I expect you to design it so that I am not going off on tangents and going nuts”
+	
+### GitHub
+
+* (R *T* g): “it’s…open to anyone…[but] it requires some technical proficiency”
+* (R *T* g): found GitHub a really valuable way of working with autistic collaborators, “because we could have a discussion”
+* (**A** **P** d): “I thought it was quite useful to have somewhere to come, I did relate to it
+* (**A** **P** d): “It was my first time using it…so I’ve got the jitters about GitHub and things like that chart forum”
+
+### Gitter 
+
+* (R *T* I): “in theory it’s open to anyone, anyone who wants to chat can make an account and join and be part of a conversation, although it may not work that way in practice”
+* (R *T* d): it can be anonymous but linked to your account
+* (**A** d): “I don’t like group chats…I get overwhelmed with it, especially if someone keeps tagging me…asking me questions, I wouldn’t really use it unless I had to”
+* (*F* i): “this sort of thing is really useful for developers, for the people who are actually involved in building the code… if you find this to be a little intimidating, I wouldn’t worry about that. There will be another way to give your thoughts and your requirements and this is most useful for the programmers”
+
+### Website
+
+* (R *T* i): “I guess this is the easiest way of finding out about the project”
+
+## 8. Ways of working
+
+### General
+
+* (*F* d): “…at this stage we’re a really blank piece of paper, and we’d like to get some initial thoughts from you guys that we can then put onto our backlog”
+
+### Collaborative
+
+* (*F* d): “…what I’d really love to see is the connections just to be created between people, if you want to know about something, if somebody from our team wants to understand something from your perspective, let’s have that conversation”
+* (*F* d): “there’ll be some members of the team that you’ll work with more regularly, so we need some form of structure to this”
+* (*F* **P** d): “it’s very important that you’re engaged throughout this process, because really we’re building this for you, and with you”
+
+### Agile
+
+* (*F* d): “agile doesn’t lend itself to sort of old style, traditional project management, but it does still require a degree of structure to it”
+* (*F* d): “devops as a concept is essentially where you put your programmers and your operations people together, then we get things to happen much more quickly”
+* (*F* d): “– that’s what agile is all about, we can change direction if we need to, if we’re going down the wrong track it’s very easy for us to just stop and go with the new requirement”
+* (**P** *F* d): “bring stakeholders in really early into the conversation and talk to them lots, on regular occasions, and then show them throughout the entire lifecycle”
+* (**P** *F* d): requests always go on the backlog, it doesn’t mean that they will be built, but they will be prioritised 
+* (P** *F* d): “The reason that it always, always goes on the list is because it might not be a good idea today, but it might be an incredible idea in a while”
+* (**P** *F* d): “we try to keep the acceptance criteria as crisp and clean as possible”
+* (**P** *F* d): “very generally you want a really stable velocity”
+* (**P** *F* d): flexible in pulling backlog into sprints depending on team’s capacity
+* (**P** *F* d): “in each one of these two-week cycles, not only are we doing planning, we build it, we automate it, we test it, we document it and we review it”
+* (**P** *F* d): preparing marketing plans and preparing communications also often part of the sprint
+* (**P** *F* d): “it’s really important that we do [stand up] every day, because that’s holding each other accountable to the commitments that we’ve made”
+* (**P** *F* d): “we want to keep that backlog really clean, because there’s nothing as scary as an out of control list”
+* (**P** *F* d): have a retrospective immediately after sprint is finished and product is demonstrated to stakeholders
+* (**P** *F* d): “that means that throughout the entire lifecycle we’re constantly tweaking and tuning how we work together”
+* (**A** g): “how do you ensure that you have a common language with your comms and your marketing people, and that they are up to speed with what you’re doing?”
+* (**P** *F* d): “they will be with us the entire time…they will be included because their tasks will be a part of the delivery goals”
+* (**F** g): “how do we make sure that what we’re doing…against our branch isn’t being replicated?”
+* (**P** *F* d): ‘this co-design should be the product owner and the scrum master doing a really good job with that backlog review”
+* (*F* g): “it would all be centrally managed in terms of the integration of the development of features by…The Alan Turing”
+
+### Open
+
+* (*F* d): “I’ve taken a fork off of the Alan Turing repository and we kind of have our own dedicated branch for this interface piece of work that we’re going to be involved with, but that’s also public”
+* (R, *T* d): “the benefit of building it in an open source way is that if we aren’t able to do [a feature like translation] … another community might be able to, and we’d be able to facilitate that.”
+* (*F* d): “given the fact that…the GitHub repository is open to anyone in the world who is interested in contributing to the project…in Fujitsu we are mobilised, with our talented developers, to tap into this” 


### PR DESCRIPTION
This PR creates a markdown document for the summaries for the 2019 focus groups, and contains the focus group held on the 18th. 

I'd appreciate comments on: 
the formatting
any typos or corrections which need to be made? 

I will add in another commit the other two summaries, and a contents page and link