### PR TITLE
Create backlog-refinement-2020-03-31.md

### DIFF
--- a/project-management/Fujitsu-Meeting-Notes/backlog-refinement/backlog-refinement-31-03-2020.md
+++ b/project-management/Fujitsu-Meeting-Notes/backlog-refinement/backlog-refinement-31-03-2020.md
@@ -1,0 +1,64 @@
+# Backlog Refinement 03-31-2020
+
+### Useful Links:
+
+* Business Requirements: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/94
+* Agile and Open Source Working: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/97
+* Create Demo Video: https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/116
+* Sprint Meetings Documentation: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/123
+* Wireframes: https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/103
+* Documentation on Sprint Progress:  https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/115
+* Ethics Approval: https://github.com/alan-turing-institute/AutisticaCitizenScience/tree/master/project-management
+
+
+### The Front-End Interface: High Level Requirements
+
+* Clearly and accessibly informs users about the project, the platform, what it is for and how to use it.
+* Registers users and collects necessary demographic information, such as connection to autism, and is compliant with the UK Data Protection Act.
+* Takes input from users reporting their experiences navigating different sensory environments.
+* Securely transfers data from users categorised as usable for research and/or usable for public view, or neither, to the Open Humans backend file management system.
+* Allows moderation of input before it is made public.
+* Presents users with their own data and consent decisions.
+* Displays experiences that have been consented for public view to any visitor of the website.
+
+
+### Backlog Prioritisation: 
+
+* Fujitsu team to review and agree business requirements: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/94
+* Review and agree agile open source working process: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/97
+* Create sprint report and demo Video https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/116
+    * Create documentation on wireframes, sprint report (preparatory work) provide links on GitHub to where hosted - record of decisions made and processes done - co-working session Georgia and Chris to put everything on GitHub
+* Complete Sprint Meetings Documentation: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/123
+* Document backlog definitions (user stories and goals): https://github.com/alan-turing-institute/AutisticaCitizenScience/issues/103
+* Link 1:1 user testing documentation to ways of working: https://github.com/alan-turing-institute/AutisticaCitizenScience/pull/115
+    Speak to community members to clarify structure they would like to be followed - document conversations - make this part of the     review of the workflow documentation pull requests (linked above)
+* Move closed work on wireframes and personas onto main GitHub repo
+* Drill down into business requirements to clarify acceptance criteria: speak to the community
+* (How): Define strategy for how will go about talking to community to gather info for acceptance criteria - process of speaking to community can happen at the same time - create in conjunction with the community so community driven 
+
+### GA Actions: 
+
+* Publish summaries on GitHub (put into markdown and incorporate SI's suggestions)
+* Go through Repo and organise - pull requests, labels, issues, milestones 
+* Write up meeting on 27th put into markdown 
+* Put Fujitsu team in touch with community member for process review  
+* Set up co-working session with CL 
+
+### Other Notes
+
+* Focus on documentation, process, and defining acceptance criteria before development work begins
+* Full sprint not yet in progress - preparatory work has occured, but interative design not yet in place - but a full sprint report will be published 
+* Tease out items from wireframe that need to be developed first 
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This adds organised notes from the backlog refinement meeting on 31st March 2020
@driscolle I have a list of attendees I can email you - would you be able to check if they are happy having their names and GitHub IDs published here? They added it themselves to the original HackMd, so I guess they would be fine, but best to double check and totally okay to keep it anonymous if preferred! 